### PR TITLE
fix: store HistorySync events so past conversations populate the chat list

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -241,6 +241,10 @@ func (a *Api) mainEventHandler(evt any) {
 			log.Println("Messages DB migration completed successfully")
 			runtime.EventsEmit(a.ctx, "wa:chat_list_refresh")
 		}
+	case *events.HistorySync:
+		// whatsmeow delivers past conversations here after linking. Reuse the
+		// same storage path as live messages so chats/history populate the UI.
+		a.processHistorySync(v)
 	case *events.Disconnected:
 		a.waClient.SendPresence(a.ctx, types.PresenceUnavailable)
 	case *events.Receipt:
@@ -252,4 +256,40 @@ func (a *Api) mainEventHandler(evt any) {
 		// Ignore other events for now
 	}
 
+}
+
+// processHistorySync stores the messages contained in a whatsmeow HistorySync
+// event. WhatsApp sends these in several batches after a device is linked
+// (bootstrap, recent, full). Each conversation's WebMessageInfo entries are
+// converted into the same *events.Message shape that live messages use, then
+// persisted through the existing MessageStore so the chat list and history
+// render exactly like incoming messages do.
+func (a *Api) processHistorySync(v *events.HistorySync) {
+	conversations := v.Data.GetConversations()
+	if len(conversations) == 0 {
+		return
+	}
+	stored := 0
+	for _, conv := range conversations {
+		chatJID, err := types.ParseJID(conv.GetID())
+		if err != nil {
+			continue
+		}
+		for _, histMsg := range conv.GetMessages() {
+			webMsg := histMsg.GetMessage()
+			if webMsg == nil {
+				continue
+			}
+			parsedMsg, err := a.waClient.ParseWebMessage(chatJID, webMsg)
+			if err != nil || parsedMsg.Message == nil {
+				continue
+			}
+			parsedHTML := a.processMessageText(parsedMsg.Message)
+			if a.messageStore.ProcessMessageEvent(a.ctx, a.waClient.Store.LIDs, parsedMsg, parsedHTML) != "" {
+				stored++
+			}
+		}
+	}
+	log.Printf("History sync: stored %d messages from %d conversations", stored, len(conversations))
+	runtime.EventsEmit(a.ctx, "wa:chat_list_refresh")
 }


### PR DESCRIPTION
## Problem
On a fresh device link the chat list comes up empty even though pairing succeeds. The main event handler in `api/api.go` has cases for `events.Message`, `Picture`, `Connected`, `Disconnected`, and `Receipt`, but **none for `*events.HistorySync`**. WhatsApp delivers past conversations in HistorySync batches after linking, so all of that message history was hitting the `default` case and being silently discarded. Contacts/groups/keys survived only because whatsmeow stores those internally.

This is the `Full chat history sync (TODO)` noted in the README.

## Fix
Add a `*events.HistorySync` case that walks each conversation's `WebMessageInfo` entries, converts them with `Client.ParseWebMessage`, and stores them through the **existing** `MessageStore.ProcessMessageEvent` path (the same one live messages use), then emits `wa:chat_list_refresh`. No new storage code — it reuses the live-message pipeline, so decoding/media-metadata handling stays consistent.

## Testing
Linux/Wayland, WebKitGTK 2.52, Go 1.26, `wails build -tags webkit2_41`. After a fresh link, ~13k messages across ~196 conversations synced into `messages.db` and the chat list populated with real history (bootstrap batch is empty as expected; recent + full batches store correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)