### PR TITLE
fix: don't blank the whole chat list when one group/contact lookup fails

### DIFF
--- a/api/chat.go
+++ b/api/chat.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"log"
+
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -19,24 +21,36 @@ func (a *Api) GetChatList() ([]ChatElement, error) {
 		if cm.JID.Server == types.GroupServer {
 			groupInfo, err := a.cw.FetchGroup(cm.JID.String())
 			if err != nil {
-				return nil, err
-			}
-			fc = Contact{
-				JID:      cm.JID.String(),
-				FullName: groupInfo.Name,
+				// A single unknown/left group must not blank the whole chat
+				// list. Fall back to the JID so the chat still renders.
+				log.Println("GetChatList: group lookup failed, using fallback:", cm.JID.String(), err)
+				fc = Contact{
+					JID:      cm.JID.String(),
+					FullName: cm.JID.User,
+				}
+			} else {
+				fc = Contact{
+					JID:      cm.JID.String(),
+					FullName: groupInfo.Name,
+				}
 			}
 		} else {
 			contact, err := a.waClient.Store.Contacts.GetContact(a.ctx, cm.JID)
 			if err != nil {
-				return nil, err
-			}
-
-			fc = Contact{
-				JID:        cm.JID.String(),
-				Short:      contact.FirstName,
-				FullName:   contact.FullName,
-				PushName:   contact.PushName,
-				IsBusiness: contact.BusinessName != "",
+				// Same here: degrade to the JID rather than failing everything.
+				log.Println("GetChatList: contact lookup failed, using fallback:", cm.JID.String(), err)
+				fc = Contact{
+					JID:      cm.JID.String(),
+					PushName: cm.JID.User,
+				}
+			} else {
+				fc = Contact{
+					JID:        cm.JID.String(),
+					Short:      contact.FirstName,
+					FullName:   contact.FullName,
+					PushName:   contact.PushName,
+					IsBusiness: contact.BusinessName != "",
+				}
 			}
 		}
 		ce[i] = ChatElement{


### PR DESCRIPTION
## Problem
`GetChatList` in `api/chat.go` does `return nil, err` on the first `FetchGroup`/`GetContact` failure. A single unknown or left group — present in message history but not in the joined-groups store — therefore wipes **every** chat from the UI (the frontend turns the error into `setChats([])`). This is easy to hit once real history is present: any group you've left still appears in history but can't be fetched.

## Fix
Degrade gracefully per-chat instead of failing the whole list: on a failed group/contact lookup, fall back to a `Contact` built from the JID (and log it). That chat still renders (named by its JID) and the rest of the list is unaffected.

## Testing
Linux/Wayland, Go 1.26. With ~196 chats loaded, two left groups were failing `FetchGroup`; before this change the list was empty, after it all 196 chats render and the two fall back to their JID. Log shows: `GetChatList: group lookup failed, using fallback: …@g.us … not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)