### PR TITLE
fix: media rendering + GIF playback (sizing, click-to-load, looping)

### DIFF
--- a/frontend/src/components/chat/MediaContent.tsx
+++ b/frontend/src/components/chat/MediaContent.tsx
@@ -113,7 +113,14 @@ export function MediaContent({
         </div>
       )
     }
-    if (type === "video") return <video src={mediaSrc} controls className="max-w-full rounded-lg" />
+    if (type === "video")
+      return (
+        <video
+          src={mediaSrc}
+          controls
+          className="block min-w-75 max-w-82.5 max-h-100 rounded-lg"
+        />
+      )
     if (type === "audio") return <audio src={mediaSrc} controls className="w-full" />
   }
 
@@ -123,7 +130,7 @@ export function MediaContent({
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-500" />
       ) : (
         <button
-          onClick={type === "video" || type === "audio" ? handleDownload : loadFromCache}
+          onClick={handleDownload}
           className="bg-black/50 p-3 rounded-full text-white hover:bg-black/70"
         >
           <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">

--- a/frontend/src/components/chat/MediaContent.tsx
+++ b/frontend/src/components/chat/MediaContent.tsx
@@ -1,13 +1,17 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { store } from "../../../wailsjs/go/models"
 import { GetCachedImage, DownloadMedia } from "../../../wailsjs/go/api/Api"
 
 // TODO: fix word wrap for longer words in content
 
+// GIFs (WhatsApp sends them as short muted videos) loop a few times then stop.
+const MAX_GIF_LOOPS = 3
+
 interface MediaContentProps {
   message: store.DecodedMessage
   type: "image" | "video" | "sticker" | "audio" | "document"
   chatId: string
+  isGif?: boolean
   sentMediaCache?: React.MutableRefObject<Map<string, string>>
   onImageClick?: (src: string) => void
   onDownload?: () => void
@@ -17,6 +21,7 @@ export function MediaContent({
   message,
   type,
   chatId,
+  isGif,
   sentMediaCache,
   onImageClick,
   onDownload,
@@ -24,6 +29,7 @@ export function MediaContent({
   const [mediaSrc, setMediaSrc] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [showDownloadButton, setShowDownloadButton] = useState(false)
+  const gifLoopsRef = useRef(0)
 
   const loadFromCache = async () => {
     if (loading) return
@@ -78,6 +84,15 @@ export function MediaContent({
     }
   }
 
+  // GIFs should start on their own like a real GIF, so fetch eagerly.
+  // Regular videos still wait for a user click.
+  useEffect(() => {
+    if (type === "video" && isGif && !mediaSrc && !loading) {
+      handleDownload()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type, isGif, message.Info.ID])
+
   if (mediaSrc) {
     if (type === "image" || type === "sticker") {
       return (
@@ -114,7 +129,30 @@ export function MediaContent({
       )
     }
     if (type === "video")
-      return (
+      return isGif ? (
+        <video
+          src={mediaSrc}
+          autoPlay
+          muted
+          playsInline
+          onEnded={e => {
+            if (gifLoopsRef.current < MAX_GIF_LOOPS - 1) {
+              gifLoopsRef.current += 1
+              const v = e.currentTarget
+              v.currentTime = 0
+              void v.play().catch(() => {})
+            }
+          }}
+          onClick={e => {
+            // Replay from the start when clicked, even after it has stopped.
+            const v = e.currentTarget
+            gifLoopsRef.current = 0
+            v.currentTime = 0
+            void v.play().catch(() => {})
+          }}
+          className="block min-w-75 max-w-82.5 max-h-100 rounded-lg cursor-pointer"
+        />
+      ) : (
         <video
           src={mediaSrc}
           controls

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -159,6 +159,7 @@ export function MessageItem({
             message={message}
             type="video"
             chatId={chatId}
+            isGif={!!content.videoMessage.gifPlayback}
             sentMediaCache={sentMediaCache}
           />
           {renderCaption(content.videoMessage.caption)}

--- a/internal/query/message_media.go
+++ b/internal/query/message_media.go
@@ -13,14 +13,26 @@ const (
 		file_enc_sha256 BLOB,
 		width INTEGER,
 		height INTEGER,
-		file_name TEXT
+		file_name TEXT,
+		gif_playback INTEGER DEFAULT 0
 	);
+	`
+
+	// AddGifPlaybackColumn migrates existing message_media tables that predate
+	// the gif_playback column. SQLite has no ADD COLUMN IF NOT EXISTS, so the
+	// caller ignores the "duplicate column" error on subsequent runs.
+	AddGifPlaybackColumn = `
+	ALTER TABLE message_media ADD COLUMN gif_playback INTEGER DEFAULT 0;
 	`
 
 	InsertMessageMedia = `
 	INSERT OR REPLACE INTO message_media
-	(message_id, type, url, mimetype, direct_path, media_key, file_sha256, file_enc_sha256, width, height, file_name)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+	(message_id, type, url, mimetype, direct_path, media_key, file_sha256, file_enc_sha256, width, height, file_name, gif_playback)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+	`
+
+	SelectGifPlaybackByMessageID = `
+	SELECT gif_playback FROM message_media WHERE message_id = ?;
 	`
 
 	UpdateMessageMediaByMessageID = `

--- a/internal/store/message.go
+++ b/internal/store/message.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/lugvitc/whats4linux/internal/misc"
@@ -83,6 +84,7 @@ type ExtendedTextContent struct {
 type MediaMessageContent struct {
 	Caption     string       `json:"caption,omitempty"`
 	Mimetype    string       `json:"mimetype,omitempty"`
+	GifPlayback bool         `json:"gifPlayback,omitempty"`
 	ContextInfo *ContextInfo `json:"contextInfo,omitempty"`
 }
 
@@ -139,6 +141,11 @@ func NewMessageStore() (*MessageStore, error) {
 		_, err = tx.Exec(query.CreateMessageMediaTable)
 		if err != nil {
 			return err
+		}
+		// Migrate pre-existing tables: add gif_playback if missing. Ignore the
+		// "duplicate column name" error that occurs once the column exists.
+		if _, aerr := tx.Exec(query.AddGifPlaybackColumn); aerr != nil && !strings.Contains(aerr.Error(), "duplicate column") {
+			return aerr
 		}
 		_, err = tx.Exec(query.CreatePinnedMessagesTable)
 		if err != nil {
@@ -501,6 +508,10 @@ func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Messag
 
 	text, fileName, replyToMessageID, forwarded, emc, mediaType, width, height = extractMessageContent(msg)
 
+	// gifPlayback marks a video that should loop like a GIF. GetVideoMessage is
+	// nil-safe and returns false for non-video messages.
+	gifPlayback := msg.GetVideoMessage().GetGifPlayback()
+
 	if parsedHTML != "" {
 		text = parsedHTML
 	}
@@ -537,6 +548,7 @@ func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Messag
 			emc.GetFileEncSHA256(),
 			width, height,
 			fileName,
+			gifPlayback,
 		)
 		return err
 	})
@@ -1102,7 +1114,7 @@ func (ms *MessageStore) GetDecodedMessagesPaged(chatJID string, beforeTimestamp 
 		}
 
 		// Populate Content for frontend rendering
-		msg.Content = ms.buildDecodedContent(chatJID, text.String, msg.ReplyToMessageID, fileName.String, msg.Type)
+		msg.Content = ms.buildDecodedContent(chatJID, msgId, text.String, msg.ReplyToMessageID, fileName.String, msg.Type)
 
 		messages = append(messages, msg)
 	}
@@ -1112,7 +1124,7 @@ func (ms *MessageStore) GetDecodedMessagesPaged(chatJID string, beforeTimestamp 
 
 // buildDecodedContent creates a DecodedMessageContent from DecodedMessage fields
 func (ms *MessageStore) buildDecodedContent(
-	chatJID, text, replyToMessageId, fileName string,
+	chatJID, messageID, text, replyToMessageId, fileName string,
 	mediaType mtypes.MediaType,
 ) *DecodedMessageContent {
 	content := &DecodedMessageContent{}
@@ -1155,6 +1167,7 @@ func (ms *MessageStore) buildDecodedContent(
 	case mtypes.MediaTypeVideo:
 		content.VideoMessage = &MediaMessageContent{
 			Caption:     text,
+			GifPlayback: ms.isGifPlayback(messageID),
 			ContextInfo: contextInfo,
 		}
 	case mtypes.MediaTypeAudio:
@@ -1176,6 +1189,19 @@ func (ms *MessageStore) buildDecodedContent(
 	}
 
 	return content
+}
+
+// isGifPlayback reports whether a video message was flagged as GIF playback
+// (short, looping, muted). Missing rows / older messages default to false.
+func (ms *MessageStore) isGifPlayback(messageID string) bool {
+	if messageID == "" {
+		return false
+	}
+	var gif sql.NullBool
+	if err := ms.db.QueryRow(query.SelectGifPlaybackByMessageID, messageID).Scan(&gif); err != nil {
+		return false
+	}
+	return gif.Bool
 }
 
 // GetDecodedMessage returns a single decoded message from messages.db
@@ -1238,7 +1264,7 @@ func (ms *MessageStore) GetDecodedMessage(chatJID string, messageID string) (*De
 	}
 
 	// Populate Content for frontend rendering
-	msg.Content = ms.buildDecodedContent(chatJID, text.String, msg.ReplyToMessageID, fileName.String, msg.Type)
+	msg.Content = ms.buildDecodedContent(chatJID, messageID, text.String, msg.ReplyToMessageID, fileName.String, msg.Type)
 
 	return &msg, nil
 }
@@ -1302,7 +1328,7 @@ func (ms *MessageStore) GetDecodedChatList() ([]DecodedMessage, error) {
 		}
 
 		// Populate Content for frontend rendering
-		msg.Content = ms.buildDecodedContent(chat, text.String, msg.ReplyToMessageID, fileName.String, msg.Type)
+		msg.Content = ms.buildDecodedContent(chat, messageId, text.String, msg.ReplyToMessageID, fileName.String, msg.Type)
 
 		messages = append(messages, msg)
 	}


### PR DESCRIPTION
Three related media-rendering fixes in `MediaContent.tsx` (+ backend support for the last one).

## 1. GIFs/videos no longer render tiny
`<video>` had only `max-w-full`, so low-resolution clips (WhatsApp sends GIFs as video) displayed at their tiny intrinsic size. Added a `min-w-75 max-w-82.5 max-h-100` box so they scale like images.

## 2. Uncached images are loadable
The image/sticker placeholder's click handler called `loadFromCache` (cache read only), so a pic that was never auto-cached (e.g. media from history) could never be displayed — clicking did nothing. Routed the click to `handleDownload` so it fetches on demand via `DownloadMedia` and caches the result.

## 3. GIF playback
WhatsApp GIFs are muted MP4s flagged `gifPlayback`, but were shown as a static `<video controls>` that played once. Now they auto-play, loop a few times then stop, and replay from the start on click; regular videos keep click-to-load + controls.

To make this work the `gifPlayback` flag is persisted: a `gif_playback` column on `message_media` (with an `ALTER`-based migration for existing DBs), populated in `InsertMessage` from `VideoMessage.GetGifPlayback()`, and surfaced on `MediaMessageContent` via a lookup in `buildDecodedContent`. Note: only messages inserted after this change carry the flag; pre-existing rows default to non-GIF until re-synced.

## Testing
Linux/Wayland, Go 1.26, `wails build -tags webkit2_41`. Verified: tiny GIFs now size correctly, previously-blank pics load on click, and newly-received GIFs autoplay/loop/replay-on-click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)