### PR TITLE
docs: note gst-plugins-good as a Linux runtime dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ This document outlines how to get started and what we expect from contributors.
 - Node.js **20.19.6+**
 - Wails v2
 - Platform dependencies:
-  - **Linux**: `gtk3`, `webkit2gtk`
+  - **Linux**: `gtk3`, `webkit2gtk`, and `gst-plugins-good` (runtime — required for
+    audio/video playback; WebKitGTK's media pipeline needs it, and without it the
+    web process crashes when a message with media is opened)
   - **Windows / macOS**: follow Wails platform setup
 
 Refer to the official Wails documentation for platform-specific setup.


### PR DESCRIPTION
On distros where `gst-plugins-good` is only an *optional* dep of webkit2gtk (e.g. Arch), it isn't installed automatically. Without it, WebKitGTK's media pipeline can't create `autoaudiosink`/`qtdemux`, so:

- the web process **crashes** when a chat message with media is opened, and
- audio/video won't play.

This adds it to the documented Linux prerequisites so users don't hit a hard-to-diagnose crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)