### PR TITLE
feat: perf, media, links, reactions, channels & status (feature batch)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -187,8 +187,9 @@ func (a *Api) mainEventHandler(evt any) {
 		}
 
 		// Raise a desktop notification for genuine incoming messages (not our
-		// own, not reactions) while the window is in the background.
-		if messageID != "" && !v.Info.IsFromMe && v.Message.GetReactionMessage() == nil && !a.windowFocused.Load() {
+		// own, not reactions, not channel/broadcast posts) while backgrounded.
+		isFeed := v.Info.Chat.Server == types.NewsletterServer || v.Info.Chat.Server == types.BroadcastServer
+		if messageID != "" && !v.Info.IsFromMe && !isFeed && v.Message.GetReactionMessage() == nil && !a.windowFocused.Load() {
 			go a.notifyIncoming(v, parsedHTML)
 		}
 

--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	"github.com/gen2brain/beeep"
 
 	"github.com/lugvitc/whats4linux/internal/cache"
 	"github.com/lugvitc/whats4linux/internal/misc"
@@ -24,12 +29,39 @@ import (
 
 // Api struct
 type Api struct {
-	ctx          context.Context
-	cw           *wa.AppDatabase
-	waClient     *whatsmeow.Client
-	messageStore *store.MessageStore
-	imageCache   *cache.ImageCache
-	us           *socket.UnixSocket
+	ctx           context.Context
+	cw            *wa.AppDatabase
+	waClient      *whatsmeow.Client
+	messageStore  *store.MessageStore
+	imageCache    *cache.ImageCache
+	us            *socket.UnixSocket
+	windowFocused atomic.Bool
+}
+
+// htmlTagRE strips HTML tags from message previews so desktop notifications
+// show plain text rather than markup.
+var htmlTagRE = regexp.MustCompile(`<[^>]*>`)
+
+// SetWindowFocused is called by the frontend on window focus/blur so the
+// backend only raises notifications while the window is in the background.
+func (a *Api) SetWindowFocused(focused bool) {
+	a.windowFocused.Store(focused)
+}
+
+// notifyIncoming raises a desktop notification for an incoming message when the
+// window isn't focused.
+func (a *Api) notifyIncoming(v *events.Message, parsedHTML string) {
+	title := v.Info.PushName
+	if title == "" {
+		title = "New message"
+	}
+	body := strings.TrimSpace(htmlTagRE.ReplaceAllString(parsedHTML, ""))
+	if body == "" {
+		body = "Sent you a message"
+	}
+	if err := beeep.Notify(title, body, ""); err != nil {
+		log.Println("notify failed:", err)
+	}
 }
 
 // NewApi creates a new Api application struct
@@ -49,6 +81,9 @@ func (a *Api) Shutdown(ctx context.Context) {
 // startup is called when the app starts. The context is saved
 // so we can call the runtime methods
 func (a *Api) Startup(ctx context.Context) {
+	// The window is focused when the app launches; the frontend keeps this in
+	// sync via SetWindowFocused so we don't notify while the user is looking.
+	a.windowFocused.Store(true)
 	var err error
 	a.us, err = socket.NewUnixSocket(ctx)
 	if err != nil {
@@ -144,10 +179,17 @@ func (a *Api) mainEventHandler(evt any) {
 					"messageText": parsedHTML, // Text field contains HTML now, but better than nothing or we can use updatedMsg.Text
 					"timestamp":   v.Info.Timestamp.Unix(),
 					"sender":      v.Info.PushName,
+					"isFromMe":    v.Info.IsFromMe,
 				})
 			} else if !errors.Is(err, sql.ErrNoRows) {
 				log.Println("Failed to get decoded message after processing:", err)
 			}
+		}
+
+		// Raise a desktop notification for genuine incoming messages (not our
+		// own, not reactions) while the window is in the background.
+		if messageID != "" && !v.Info.IsFromMe && v.Message.GetReactionMessage() == nil && !a.windowFocused.Load() {
+			go a.notifyIncoming(v, parsedHTML)
 		}
 
 		if reaction := v.Message.GetReactionMessage(); reaction != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -327,6 +327,12 @@ func (a *Api) processHistorySync(v *events.HistorySync) {
 			if err != nil || parsedMsg.Message == nil {
 				continue
 			}
+			// ParseWebMessage doesn't unwrap containers (ephemeral/view-once)
+			// like the live path does, so do it here or the content is lost.
+			parsedMsg.Message = store.UnwrapMessage(parsedMsg.Message)
+			if parsedMsg.Message == nil {
+				continue
+			}
 			parsedHTML := a.processMessageText(parsedMsg.Message)
 			if a.messageStore.ProcessMessageEvent(a.ctx, a.waClient.Store.LIDs, parsedMsg, parsedHTML) != "" {
 				stored++

--- a/api/chat.go
+++ b/api/chat.go
@@ -63,6 +63,26 @@ func (a *Api) GetChatList() ([]ChatElement, error) {
 	return ce, nil
 }
 
+// GetChannelList returns the followed Channels (newsletter feeds), named via
+// their newsletter metadata.
+func (a *Api) GetChannelList() ([]ChatElement, error) {
+	cmList := a.messageStore.GetChannelList()
+	ce := make([]ChatElement, len(cmList))
+	for i, cm := range cmList {
+		name := cm.JID.User
+		if info, err := a.waClient.GetNewsletterInfo(a.ctx, cm.JID); err == nil && info != nil && info.ThreadMeta.Name.Text != "" {
+			name = info.ThreadMeta.Name.Text
+		}
+		ce[i] = ChatElement{
+			LatestMessage: cm.MessageText,
+			LatestTS:      cm.MessageTime,
+			Sender:        cm.Sender,
+			Contact:       Contact{JID: cm.JID.String(), FullName: name},
+		}
+	}
+	return ce, nil
+}
+
 func (a *Api) SendChatPresence(jid string, cp types.ChatPresence, cpm types.ChatPresenceMedia) error {
 	parsedJid, err := types.ParseJID(jid)
 	if err != nil {

--- a/api/media.go
+++ b/api/media.go
@@ -17,6 +17,52 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+// LinkPreviewResult is the link preview surfaced to the frontend.
+type LinkPreviewResult struct {
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Thumbnail   string `json:"thumbnail"` // data URL, or empty
+}
+
+// GetLinkPreview returns the stored preview card for a message's URL, or nil.
+func (a *Api) GetLinkPreview(messageID string) *LinkPreviewResult {
+	lp := a.messageStore.GetLinkPreview(messageID)
+	if lp == nil {
+		return nil
+	}
+	res := &LinkPreviewResult{URL: lp.URL, Title: lp.Title, Description: lp.Description}
+	if len(lp.Thumbnail) > 0 {
+		res.Thumbnail = "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(lp.Thumbnail)
+	}
+	return res
+}
+
+// GetLinkPreviewImage returns the preview poster as a data URL, downloading and
+// caching it on first request (WhatsApp ships the poster as an encrypted
+// reference rather than embedded). Empty string if there's nothing to fetch.
+func (a *Api) GetLinkPreviewImage(messageID string) string {
+	m := a.messageStore.GetLinkPreviewMedia(messageID)
+	if m == nil {
+		return ""
+	}
+	if len(m.Thumbnail) > 0 {
+		return "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(m.Thumbnail)
+	}
+	if m.DirectPath == "" || len(m.MediaKey) == 0 {
+		return ""
+	}
+	data, err := a.waClient.DownloadMediaWithPath(
+		a.ctx, m.DirectPath, m.FileEncSHA256, m.FileSHA256, m.MediaKey,
+		whatsmeow.MediaLinkThumbnail, "thumbnail-link", true,
+	)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	a.messageStore.CacheLinkPreviewThumbnail(messageID, data)
+	return "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(data)
+}
+
 // GetVideoThumbnail returns the message's embedded preview image as a data URL,
 // or an empty string if none was stored. Lets the UI show a video preview + play
 // button without downloading the full video.

--- a/api/media.go
+++ b/api/media.go
@@ -17,6 +17,17 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+// GetVideoThumbnail returns the message's embedded preview image as a data URL,
+// or an empty string if none was stored. Lets the UI show a video preview + play
+// button without downloading the full video.
+func (a *Api) GetVideoThumbnail(messageID string) string {
+	thumb := a.messageStore.GetThumbnail(messageID)
+	if len(thumb) == 0 {
+		return ""
+	}
+	return "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(thumb)
+}
+
 func (a *Api) DownloadMedia(chatJID string, messageID string) (string, error) {
 	msg, err := a.messageStore.GetMessageWithMedia(chatJID, messageID)
 	if err != nil || msg == nil {
@@ -27,8 +38,18 @@ func (a *Api) DownloadMedia(chatJID string, messageID string) (string, error) {
 	width, height := msg.Media.GetDimensions()
 
 	mediaType := msg.Media.GetMediaType()
-	if mediaType == whatsmeow.MediaImage && mime == "" {
-		mime = "image/jpeg"
+	if mime == "" {
+		// A correct MIME is required or <video>/<audio> won't play the data URL.
+		switch mediaType {
+		case whatsmeow.MediaImage:
+			mime = "image/jpeg"
+		case whatsmeow.MediaVideo:
+			mime = "video/mp4"
+		case whatsmeow.MediaAudio:
+			mime = "audio/ogg"
+		default:
+			mime = "application/octet-stream"
+		}
 	}
 	data, err := a.waClient.Download(a.ctx, msg.Media)
 	if err != nil {
@@ -43,7 +64,8 @@ func (a *Api) DownloadMedia(chatJID string, messageID string) (string, error) {
 		}
 	}
 
-	return base64.StdEncoding.EncodeToString(data), nil
+	// Return a ready-to-use data URL with the correct MIME.
+	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data), nil
 }
 
 // downloadMedia downloads media from a message and returns data, mime, width, height

--- a/api/message.go
+++ b/api/message.go
@@ -181,6 +181,31 @@ func (a *Api) buildQuotedContext(chatJID types.JID, quotedMessageID string) (*wa
 	return contextInfo, nil
 }
 
+// SendReaction reacts to a message with an emoji (empty emoji removes the
+// reaction). senderJID is the original message's sender; empty means our own.
+func (a *Api) SendReaction(chatJID, senderJID, messageID, emoji string) error {
+	if a.waClient.Store.ID == nil {
+		return fmt.Errorf("not logged in")
+	}
+	chat, err := types.ParseJID(chatJID)
+	if err != nil {
+		return err
+	}
+	sender := *a.waClient.Store.ID
+	if senderJID != "" {
+		if s, perr := types.ParseJID(senderJID); perr == nil {
+			sender = s
+		}
+	}
+	reactionMsg := a.waClient.BuildReaction(chat, sender, messageID, emoji)
+	if _, err := a.waClient.SendMessage(a.ctx, chat, reactionMsg); err != nil {
+		return err
+	}
+	// Persist our own reaction locally so it survives a reload.
+	_ = a.messageStore.AddReactionToMessage(messageID, emoji, a.waClient.Store.ID.String())
+	return nil
+}
+
 func (a *Api) SendMessage(chatJID string, content MessageContent) (string, error) {
 	if a.waClient.Store.ID == nil {
 		return "", fmt.Errorf("client not logged in")

--- a/api/user.go
+++ b/api/user.go
@@ -8,6 +8,15 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+// GetMyJID returns the logged-in user's phone-number part, used to identify
+// which reactions are our own (for toggling them off).
+func (a *Api) GetMyJID() string {
+	if a.waClient.Store.ID == nil {
+		return ""
+	}
+	return a.waClient.Store.ID.User
+}
+
 func (a *Api) GetProfile(jidStr string) (Contact, error) {
 	var targetJID types.JID
 	if jidStr == "" {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { Login, GetCustomCSS, GetCustomJS } from "../wailsjs/go/api/Api"
+import { Login, GetCustomCSS, GetCustomJS, SetWindowFocused } from "../wailsjs/go/api/Api"
 import { EventsOn } from "../wailsjs/runtime/runtime"
 import QRCode from "qrcode"
 import { ChatListScreen } from "./screens/ChatScreen"
@@ -32,6 +32,20 @@ function App() {
       }
     }
   }, [theme, loaded])
+
+  // Keep the backend informed of window focus so it only notifies when the
+  // window is in the background.
+  useEffect(() => {
+    const onFocus = () => SetWindowFocused(true)
+    const onBlur = () => SetWindowFocused(false)
+    window.addEventListener("focus", onFocus)
+    window.addEventListener("blur", onBlur)
+    SetWindowFocused(document.hasFocus())
+    return () => {
+      window.removeEventListener("focus", onFocus)
+      window.removeEventListener("blur", onBlur)
+    }
+  }, [])
 
   useEffect(() => {
     Login()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ChatListScreen } from "./screens/ChatScreen"
 import { LoginScreen } from "./screens/LoginScreen"
 import { SettingsScreen } from "./screens/SettingsScreen"
 import { initSelf } from "./lib/self"
+import { Lightbox } from "./components/Lightbox"
 
 import { useUIStore } from "./store"
 import { useAppSettingsStore } from "./store/useAppSettingsStore"
@@ -119,6 +120,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-light-secondary text-light-text dark:bg-black dark:text-white relative">
+      <Lightbox />
       <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
         {notifications.map(n => (
           <div key={n.id} className="bg-zinc-800 text-white px-4 py-2 rounded shadow-lg">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import QRCode from "qrcode"
 import { ChatListScreen } from "./screens/ChatScreen"
 import { LoginScreen } from "./screens/LoginScreen"
 import { SettingsScreen } from "./screens/SettingsScreen"
+import { initSelf } from "./lib/self"
 
 import { useUIStore } from "./store"
 import { useAppSettingsStore } from "./store/useAppSettingsStore"
@@ -65,6 +66,7 @@ function App() {
 
   useEffect(() => {
     Login()
+    initSelf()
 
     GetCustomCSS().then(css => {
       if (css) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { Login, GetCustomCSS, GetCustomJS, SetWindowFocused } from "../wailsjs/go/api/Api"
-import { EventsOn } from "../wailsjs/runtime/runtime"
+import { EventsOn, BrowserOpenURL } from "../wailsjs/runtime/runtime"
 import QRCode from "qrcode"
 import { ChatListScreen } from "./screens/ChatScreen"
 import { LoginScreen } from "./screens/LoginScreen"
@@ -32,6 +32,22 @@ function App() {
       }
     }
   }, [theme, loaded])
+
+  // Open links inside message text in the system browser instead of navigating
+  // the app's webview. Links are rendered as <a class="msg-link"> by the backend.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null
+      const anchor = target?.closest?.("a.msg-link") as HTMLAnchorElement | null
+      if (anchor) {
+        e.preventDefault()
+        const href = anchor.getAttribute("href")
+        if (href) BrowserOpenURL(href)
+      }
+    }
+    document.addEventListener("click", onClick)
+    return () => document.removeEventListener("click", onClick)
+  }, [])
 
   // Keep the backend informed of window focus so it only notifies when the
   // window is in the background.

--- a/frontend/src/components/Lightbox.tsx
+++ b/frontend/src/components/Lightbox.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react"
+import clsx from "clsx"
+import { useUIStore } from "../store"
+
+// Full-screen image viewer. Click the backdrop or × or Esc to close; click the
+// image to toggle zoom.
+export function Lightbox() {
+  const src = useUIStore(s => s.lightboxSrc)
+  const kind = useUIStore(s => s.lightboxKind)
+  const close = useUIStore(s => s.closeLightbox)
+  const [zoomed, setZoomed] = useState(false)
+
+  useEffect(() => {
+    if (!src) return
+    setZoomed(false)
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [src, close])
+
+  if (!src) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center overflow-auto bg-black/90"
+      onClick={close}
+    >
+      <button
+        onClick={close}
+        title="Close (Esc)"
+        className="absolute right-4 top-3 text-3xl leading-none text-white/80 hover:text-white"
+      >
+        ×
+      </button>
+      {kind === "video" ? (
+        <video
+          src={src}
+          controls
+          autoPlay
+          controlsList="nofullscreen"
+          disablePictureInPicture
+          onClick={e => e.stopPropagation()}
+          className="h-[95vh] w-[95vw] object-contain"
+        />
+      ) : (
+        <img
+          src={src}
+          alt=""
+          onClick={e => {
+            e.stopPropagation()
+            setZoomed(z => !z)
+          }}
+          className={clsx(
+            "select-none transition-transform",
+            zoomed
+              ? "max-h-none max-w-none scale-150 cursor-zoom-out"
+              : "max-h-[92vh] max-w-[92vw] cursor-zoom-in object-contain",
+          )}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/chat/LinkPreview.tsx
+++ b/frontend/src/components/chat/LinkPreview.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react"
+import { GetLinkPreview, GetLinkPreviewImage } from "../../../wailsjs/go/api/Api"
+import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
+
+interface Preview {
+  url: string
+  title: string
+  description: string
+  thumbnail: string
+}
+
+// Renders the WhatsApp link-preview card under a message, if one was stored.
+export function LinkPreview({ messageId }: { messageId: string }) {
+  const [preview, setPreview] = useState<Preview | null>(null)
+  const [poster, setPoster] = useState<string>("")
+
+  useEffect(() => {
+    let cancelled = false
+    GetLinkPreview(messageId)
+      .then(p => {
+        if (cancelled || !p || (!p.title && !p.thumbnail)) return
+        setPreview(p as Preview)
+        // The poster is usually a downloadable reference, not embedded — fetch
+        // it lazily (downloaded + cached on first request).
+        if (!p.thumbnail) {
+          GetLinkPreviewImage(messageId)
+            .then(url => {
+              if (!cancelled && url) setPoster(url)
+            })
+            .catch(() => {})
+        }
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [messageId])
+
+  if (!preview) return null
+
+  const image = preview.thumbnail || poster
+
+  let domain = ""
+  try {
+    domain = new URL(preview.url).hostname.replace(/^www\./, "")
+  } catch {
+    /* ignore malformed URL */
+  }
+
+  return (
+    <div
+      onClick={() => preview.url && BrowserOpenURL(preview.url)}
+      className="mt-1 max-w-72 overflow-hidden rounded-lg bg-black/10 dark:bg-black/25 cursor-pointer"
+    >
+      {image && (
+        <img src={image} alt="" className="w-full max-h-64 object-contain bg-black/20" />
+      )}
+      <div className="p-2">
+        {preview.title && (
+          <div className="text-sm font-medium line-clamp-2 leading-snug">{preview.title}</div>
+        )}
+        {preview.description && (
+          <div className="mt-0.5 text-xs opacity-70 line-clamp-2">{preview.description}</div>
+        )}
+        {domain && <div className="mt-1 text-[10px] uppercase tracking-wide opacity-50">{domain}</div>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/MediaContent.tsx
+++ b/frontend/src/components/chat/MediaContent.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react"
 import { store } from "../../../wailsjs/go/models"
-import { GetCachedImage, DownloadMedia } from "../../../wailsjs/go/api/Api"
+import { GetCachedImage, DownloadMedia, GetVideoThumbnail } from "../../../wailsjs/go/api/Api"
 
 // TODO: fix word wrap for longer words in content
 
@@ -29,16 +29,31 @@ export function MediaContent({
   const [mediaSrc, setMediaSrc] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [showDownloadButton, setShowDownloadButton] = useState(false)
+  const [thumbnailSrc, setThumbnailSrc] = useState<string | null>(null)
   const gifLoopsRef = useRef(0)
+  const placeholderRef = useRef<HTMLDivElement | null>(null)
 
-  const loadFromCache = async () => {
-    if (loading) return
+  const loadFromCache = async (): Promise<string | null> => {
+    if (loading) return null
     setLoading(true)
     try {
       const imagePath = await GetCachedImage(message.Info.ID)
-      if (imagePath) {
-        setMediaSrc(imagePath)
-      }
+      if (imagePath) setMediaSrc(imagePath)
+      return imagePath || null
+    } catch (e) {
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDownload = async () => {
+    if (loading) return
+    setLoading(true)
+    try {
+      // DownloadMedia returns a ready-to-use data URL with the correct MIME.
+      const dataUrl = await DownloadMedia(chatId, message.Info.ID)
+      setMediaSrc(dataUrl)
     } catch (e) {
     } finally {
       setLoading(false)
@@ -51,15 +66,67 @@ export function MediaContent({
 
     if (messageBody?._tempImage) {
       setMediaSrc(messageBody._tempImage)
-    } else if (messageBody?._tempFile) {
+      return
+    }
+    if (messageBody?._tempFile) {
       const blobUrl = URL.createObjectURL(messageBody._tempFile)
       setMediaSrc(blobUrl)
-    } else if (sentMediaCache?.current.has(message.Info.ID)) {
+      return
+    }
+    if (sentMediaCache?.current.has(message.Info.ID)) {
       setMediaSrc(sentMediaCache.current.get(message.Info.ID)!)
-    } else if (type === "image" || type === "sticker") {
+      return
+    }
+    if (type === "image" || type === "sticker") {
+      // Show instantly if cached; otherwise the IntersectionObserver below
+      // fetches it once it's actually on screen.
       loadFromCache()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [message.Info.ID, type])
+
+  // Auto-download image/sticker media once it's visible on screen — covers both
+  // "already visible when the chat opens" and "scrolled into view". Debounced so
+  // rows blazed past during a fast scroll don't fetch.
+  useEffect(() => {
+    const autoLoads = type === "image" || type === "sticker" || (type === "video" && isGif)
+    if (mediaSrc || !autoLoads) return
+    const el = placeholderRef.current
+    if (!el) return
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          timer = setTimeout(() => handleDownload(), 200)
+        } else if (timer) {
+          clearTimeout(timer)
+          timer = undefined
+        }
+      },
+      { rootMargin: "150px", threshold: 0.01 },
+    )
+    obs.observe(el)
+    return () => {
+      obs.disconnect()
+      if (timer) clearTimeout(timer)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mediaSrc, type, isGif, message.Info.ID])
+
+  // Fetch the embedded preview for regular videos so the list shows a thumbnail
+  // + play button without downloading the whole video. (GIFs auto-play instead.)
+  useEffect(() => {
+    if (type !== "video" || isGif || mediaSrc) return
+    let cancelled = false
+    GetVideoThumbnail(message.Info.ID)
+      .then(url => {
+        if (!cancelled && url) setThumbnailSrc(url)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [type, isGif, mediaSrc, message.Info.ID])
 
   useEffect(() => {
     // Cleanup blob URLs when component unmounts or mediaSrc changes
@@ -70,28 +137,6 @@ export function MediaContent({
     }
   }, [mediaSrc])
 
-  const handleDownload = async () => {
-    if (loading) return
-    setLoading(true)
-    try {
-      const data = await DownloadMedia(chatId, message.Info.ID)
-      setMediaSrc(
-        `data:${(message.Content as any)?.[`${type}Message`]?.mimetype || "application/octet-stream"};base64,${data}`,
-      )
-    } catch (e) {
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  // GIFs should start on their own like a real GIF, so fetch eagerly.
-  // Regular videos still wait for a user click.
-  useEffect(() => {
-    if (type === "video" && isGif && !mediaSrc && !loading) {
-      handleDownload()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [type, isGif, message.Info.ID])
 
   if (mediaSrc) {
     if (type === "image" || type === "sticker") {
@@ -158,8 +203,34 @@ export function MediaContent({
     if (type === "audio") return <audio src={mediaSrc} controls className="w-full" />
   }
 
+  // Video placeholder: show the embedded thumbnail (if any) with a play button
+  // so it's clearly a video, and only download the full file on click.
+  if (type === "video") {
+    return (
+      <div
+        ref={placeholderRef}
+        onClick={handleDownload}
+        className="relative w-64 h-64 rounded-lg overflow-hidden bg-gray-300 dark:bg-gray-800 flex items-center justify-center cursor-pointer bg-cover bg-center"
+        style={thumbnailSrc ? { backgroundImage: `url(${thumbnailSrc})` } : undefined}
+      >
+        {loading ? (
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        ) : (
+          <div className="bg-black/55 rounded-full p-3">
+            <svg viewBox="0 0 24 24" width="28" height="28" fill="white">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
-    <div className="w-64 h-64 bg-gray-200 dark:bg-gray-800 rounded-lg flex items-center justify-center">
+    <div
+      ref={placeholderRef}
+      className="w-64 h-64 bg-gray-200 dark:bg-gray-800 rounded-lg flex items-center justify-center"
+    >
       {loading ? (
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-500" />
       ) : (

--- a/frontend/src/components/chat/MediaContent.tsx
+++ b/frontend/src/components/chat/MediaContent.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react"
 import { store } from "../../../wailsjs/go/models"
 import { GetCachedImage, DownloadMedia, GetVideoThumbnail } from "../../../wailsjs/go/api/Api"
+import { useUIStore } from "../../store"
 
 // TODO: fix word wrap for longer words in content
 
@@ -32,6 +33,7 @@ export function MediaContent({
   const [thumbnailSrc, setThumbnailSrc] = useState<string | null>(null)
   const gifLoopsRef = useRef(0)
   const placeholderRef = useRef<HTMLDivElement | null>(null)
+  const openLightbox = useUIStore(s => s.openLightbox)
 
   const loadFromCache = async (): Promise<string | null> => {
     if (loading) return null
@@ -54,6 +56,26 @@ export function MediaContent({
       // DownloadMedia returns a ready-to-use data URL with the correct MIME.
       const dataUrl = await DownloadMedia(chatId, message.Info.ID)
       setMediaSrc(dataUrl)
+    } catch (e) {
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Regular videos play full-screen in the lightbox (keeps the chat thumbnail).
+  // The downloaded data URL is cached in a ref so reopening doesn't re-download.
+  const videoDataRef = useRef<string>("")
+  const openVideo = async () => {
+    if (videoDataRef.current) {
+      openLightbox(videoDataRef.current, "video")
+      return
+    }
+    if (loading) return
+    setLoading(true)
+    try {
+      const dataUrl = await DownloadMedia(chatId, message.Info.ID)
+      videoDataRef.current = dataUrl
+      openLightbox(dataUrl, "video")
     } catch (e) {
     } finally {
       setLoading(false)
@@ -154,7 +176,14 @@ export function MediaContent({
                 : "object-contain w-48.75 h-48.75"
             }
             alt="media"
-            onClick={type === "image" && onImageClick ? () => onImageClick(mediaSrc) : undefined}
+            onClick={
+              type === "image"
+                ? () => {
+                    onImageClick?.(mediaSrc)
+                    openLightbox(mediaSrc)
+                  }
+                : undefined
+            }
           />
           {type === "image" && showDownloadButton && onDownload && (
             <button
@@ -209,7 +238,7 @@ export function MediaContent({
     return (
       <div
         ref={placeholderRef}
-        onClick={handleDownload}
+        onClick={openVideo}
         className="relative w-64 h-64 rounded-lg overflow-hidden bg-gray-300 dark:bg-gray-800 flex items-center justify-center cursor-pointer bg-cover bg-center"
         style={thumbnailSrc ? { backgroundImage: `url(${thumbnailSrc})` } : undefined}
       >

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -4,6 +4,7 @@ import { DownloadImageToFile } from "../../../wailsjs/go/api/Api"
 import { MediaContent } from "./MediaContent"
 import { QuotedMessage } from "./QuotedMessage"
 import { ReactionBubble } from "./Reactions"
+import { LinkPreview } from "./LinkPreview"
 import clsx from "clsx"
 import { MessageMenu } from "./MessageMenu"
 import { ClockPendingIcon, BlueTickIcon, ForwardedIcon } from "../../assets/svgs/chat_icons"
@@ -143,8 +144,15 @@ export function MessageItem({
   const renderContent = () => {
     if (!content) return <span className="italic opacity-50">Empty Message</span>
     else if (content.conversation || content.extendedTextMessage?.text) {
-      const htmlContent = content.conversation || content.extendedTextMessage?.text
-      return <div className="pr-5" dangerouslySetInnerHTML={{ __html: htmlContent }} />
+      const htmlContent = content.conversation || content.extendedTextMessage?.text || ""
+      return (
+        <>
+          <div className="pr-5" dangerouslySetInnerHTML={{ __html: htmlContent }} />
+          {htmlContent.includes('class="msg-link"') && (
+            <LinkPreview messageId={message.Info.ID} />
+          )}
+        </>
+      )
     } else if (content.imageMessage)
       return (
         <div className="flex flex-col">

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, lazy, Suspense } from "react"
+import emojiData from "@emoji-mart/data"
 import { store } from "../../../wailsjs/go/models"
-import { DownloadImageToFile } from "../../../wailsjs/go/api/Api"
+import { DownloadImageToFile, SendReaction } from "../../../wailsjs/go/api/Api"
 import { MediaContent } from "./MediaContent"
 import { QuotedMessage } from "./QuotedMessage"
 import { ReactionBubble } from "./Reactions"
@@ -9,6 +10,11 @@ import clsx from "clsx"
 import { MessageMenu } from "./MessageMenu"
 import { ClockPendingIcon, BlueTickIcon, ForwardedIcon } from "../../assets/svgs/chat_icons"
 import { useContactStore } from "../../store/useContactStore"
+import { useMessageStore } from "../../store"
+import { isMe } from "../../lib/self"
+
+const QUICK_REACTIONS = ["👍", "❤️", "😂", "😮", "😢", "🙏"]
+const EmojiPicker = lazy(() => import("@emoji-mart/react"))
 
 interface MessageItemProps {
   message: store.DecodedMessage
@@ -59,6 +65,9 @@ export function MessageItem({
   )
   const [senderColor, setSenderColor] = useState<string | undefined>(cachedSender?.senderColor)
   const getSenderInfo = useContactStore(state => state.getSenderInfo)
+  const addReactionToMessage = useMessageStore(state => state.addReactionToMessage)
+  const [showReactionPicker, setShowReactionPicker] = useState(false)
+  const [showFullEmoji, setShowFullEmoji] = useState(false)
   // Derived directly from the message; no state/effect needed (a state+effect
   // here forced an extra re-render per message on mount).
   const reactions = message.reactions ?? []
@@ -94,8 +103,22 @@ export function MessageItem({
     }
   }
 
-  const handleReact = () => {
-    // TODO: Implement react functionality
+  const handleReact = () => setShowReactionPicker(v => !v)
+
+  const myReaction = (reactions as any[]).find(r => isMe(r.sender_id))?.emoji as
+    | string
+    | undefined
+
+  const sendReaction = (emoji: string) => {
+    // Tapping the emoji you already reacted with removes it (WhatsApp behaviour).
+    const finalEmoji = myReaction === emoji ? "" : emoji
+    // For our own messages the reaction key's sender is us (empty -> backend
+    // fills in own JID); for received messages it's the original sender.
+    const senderJID = isFromMe ? "" : message.Info.Sender
+    SendReaction(chatId, senderJID, message.Info.ID, finalEmoji).catch(() => {})
+    addReactionToMessage(chatId, message.Info.ID, finalEmoji, "me")
+    setShowReactionPicker(false)
+    setShowFullEmoji(false)
   }
 
   const handleForward = () => {
@@ -265,6 +288,64 @@ export function MessageItem({
             },
           )}
         >
+          {/* Hover reaction trigger just outside the bubble (WhatsApp-style). */}
+          <button
+            onClick={() => setShowReactionPicker(v => !v)}
+            title="React"
+            className={clsx(
+              "absolute bottom-1 z-20 rounded-full bg-white p-1 text-sm leading-none opacity-0 shadow transition-opacity group-hover:opacity-100 dark:bg-dark-tertiary",
+              isFromMe ? "-left-9" : "-right-9",
+            )}
+          >
+            🙂
+          </button>
+
+          {showReactionPicker && (
+            <div
+              className={clsx(
+                "absolute bottom-9 z-9999 flex w-max items-center gap-1 rounded-full bg-white px-2 py-1 shadow-lg dark:bg-dark-tertiary",
+                isFromMe ? "right-0" : "left-0",
+              )}
+            >
+              {QUICK_REACTIONS.map(emoji => (
+                <button
+                  key={emoji}
+                  onClick={() => sendReaction(emoji)}
+                  className={clsx(
+                    "rounded-full px-1 text-lg leading-none transition-transform hover:scale-125",
+                    myReaction === emoji && "bg-blue-500/40",
+                  )}
+                >
+                  {emoji}
+                </button>
+              ))}
+              <button
+                onClick={() => {
+                  setShowFullEmoji(true)
+                  setShowReactionPicker(false)
+                }}
+                title="More"
+                className="ml-1 flex h-6 w-6 items-center justify-center rounded-full bg-black/10 text-sm dark:bg-white/10"
+              >
+                +
+              </button>
+            </div>
+          )}
+
+          {showFullEmoji && (
+            <div className="absolute bottom-9 z-9999" style={isFromMe ? { right: 0 } : { left: 0 }}>
+              <Suspense fallback={<div className="rounded bg-white p-2 text-xs shadow dark:bg-dark-tertiary">Loading…</div>}>
+                <EmojiPicker
+                  data={emojiData}
+                  onEmojiSelect={(e: any) => sendReaction(e.native)}
+                  onClickOutside={() => setShowFullEmoji(false)}
+                  theme="auto"
+                  previewPosition="none"
+                  skinTonePosition="none"
+                />
+              </Suspense>
+            </div>
+          )}
           {/* Message Menu - positioned at top right corner */}
           <MessageMenu
             messageId={message.Info.ID}
@@ -308,7 +389,13 @@ export function MessageItem({
 
           {/* Reactions */}
           {reactions.length > 0 && (
-            <div className={clsx("absolute -bottom-3 z-9999", isFromMe ? "right-2" : "left-2")}>
+            <div
+              onClick={() => setShowReactionPicker(v => !v)}
+              className={clsx(
+                "absolute -bottom-3 z-9999 cursor-pointer",
+                isFromMe ? "right-2" : "left-2",
+              )}
+            >
               <ReactionBubble reactions={reactions} isFromMe={isFromMe} />
             </div>
           )}

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { store } from "../../../wailsjs/go/models"
-import { DownloadImageToFile, GetContact } from "../../../wailsjs/go/api/Api"
+import { DownloadImageToFile } from "../../../wailsjs/go/api/Api"
 import { MediaContent } from "./MediaContent"
 import { QuotedMessage } from "./QuotedMessage"
 import { ReactionBubble } from "./Reactions"
@@ -34,7 +34,6 @@ export function MessageItem({
   onQuotedClick,
   highlightedMessageId,
 }: MessageItemProps) {
-  // console.log(message)
   const isFromMe = message.Info.IsFromMe
   // Debug: log every render and also when the message updates or unmounts
   // console.log(`[MessageItem] render id=${message.Info.ID} fromMe=${isFromMe} chat=${chatId}`)
@@ -47,10 +46,21 @@ export function MessageItem({
   const content = message.Content
   const isSticker = !!content?.stickerMessage
   const isPending = (message as any).isPending || false
-  const [senderName, setSenderName] = useState("~ " + message.Info.PushName || "Unknown")
-  const [senderColor, setSenderColor] = useState<string | undefined>(undefined)
-  const getContactColor = useContactStore(state => state.getContactColor)
-  const [Reactions, setReactions] = useState(message.reactions ?? [])
+  const isGroup = chatId.endsWith("@g.us")
+  // Seed sender name/color from the cache synchronously so a cached group
+  // message renders correctly on first paint and never re-renders for it.
+  const cachedSender =
+    !isFromMe && isGroup && message.Info.Sender
+      ? useContactStore.getState().contacts[message.Info.Sender]
+      : undefined
+  const [senderName, setSenderName] = useState(
+    cachedSender?.name || "~ " + message.Info.PushName || "Unknown",
+  )
+  const [senderColor, setSenderColor] = useState<string | undefined>(cachedSender?.senderColor)
+  const getSenderInfo = useContactStore(state => state.getSenderInfo)
+  // Derived directly from the message; no state/effect needed (a state+effect
+  // here forced an extra re-render per message on mount).
+  const reactions = message.reactions ?? []
 
   // Helper function to render caption with markdown
   const renderCaption = (caption: string | undefined) => {
@@ -103,28 +113,24 @@ export function MessageItem({
     // TODO: Implement delete functionality
   }
 
-  // Fetch Group Member Names (Feature #2)
+  // Fetch group member name + color from the cached store (one RPC per sender,
+  // then synchronous) so scrolling a group chat doesn't fire an RPC per row.
   useEffect(() => {
-    if (!isFromMe && message.Info.Sender && chatId.endsWith("@g.us")) {
-      // GetContact now accepts a string JID directly
-      GetContact(message.Info.Sender)
-        .then((contact: any) => {
-          if (contact?.full_name || contact?.push_name) {
-            setSenderName(contact.full_name || "~ " + contact.push_name)
-          }
-        })
-        .catch(() => {})
-      getContactColor(message.Info.Sender)
-        .then((color: string) => {
-          setSenderColor(color)
-        })
-        .catch(() => {})
+    if (isFromMe || !isGroup || !message.Info.Sender) return
+    // Already seeded from cache above — no fetch, no re-render.
+    if (useContactStore.getState().contacts[message.Info.Sender]) return
+    let cancelled = false
+    getSenderInfo(message.Info.Sender)
+      .then(({ name, color }) => {
+        if (cancelled) return
+        if (name) setSenderName(name)
+        if (color) setSenderColor(color)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
     }
-  }, [message.Info.Sender, chatId, isFromMe, getContactColor])
-
-  useEffect(() => {
-    setReactions(message.reactions ?? [])
-  }, [message.Info.ID, message.reactions])
+  }, [message.Info.Sender, isGroup, isFromMe, getSenderInfo])
 
   const contextInfo =
     content?.extendedTextMessage?.contextInfo ||
@@ -218,7 +224,6 @@ export function MessageItem({
     }
     // Note: senderKeyDistributionMessage and reactionMessage are not stored in messages.db
     // Reactions are stored separately and shown via the Reactions field
-    console.log("Unsupported message content:", content)
     return <span className="italic opacity-50 text-xs">Unsupported Message Type</span>
   }
 
@@ -237,7 +242,7 @@ export function MessageItem({
       >
         <div
           className={clsx(
-            "max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl rounded-lg p-2 mx-5 shadow-sm relative min-w-0",
+            "max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl rounded-lg p-2 mx-5 relative min-w-0",
             {
               "w-min": hasMedia,
               "bg-transparent shadow-none": isSticker,
@@ -294,9 +299,9 @@ export function MessageItem({
           </div>
 
           {/* Reactions */}
-          {Reactions && Reactions.length > 0 && (
+          {reactions.length > 0 && (
             <div className={clsx("absolute -bottom-3 z-9999", isFromMe ? "right-2" : "left-2")}>
-              <ReactionBubble reactions={Reactions} isFromMe={isFromMe} />
+              <ReactionBubble reactions={reactions} isFromMe={isFromMe} />
             </div>
           )}
         </div>

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -1,10 +1,14 @@
-import { forwardRef, useImperativeHandle, useRef, useCallback, memo, useEffect } from "react"
+import { forwardRef, useImperativeHandle, useRef, memo } from "react"
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { store } from "../../../wailsjs/go/models"
 import { MessageItem } from "./MessageItem"
 
 interface MessageListProps {
   chatId: string
   messages: store.DecodedMessage[]
+  // Virtuoso anchor for prepending older messages without a scroll jump: it
+  // decreases by the number of messages prepended (see ChatDetail).
+  firstItemIndex: number
   sentMediaCache: React.MutableRefObject<Map<string, string>>
   onReply?: (message: store.DecodedMessage) => void
   onQuotedClick?: (messageId: string) => void
@@ -18,9 +22,6 @@ interface MessageListProps {
 export interface MessageListHandle {
   scrollToBottom: (behavior?: "auto" | "smooth") => void
   scrollToMessage: (messageId: string) => void
-  getScrollHeight: () => number
-  getScrollTop: () => number
-  setScrollTop: (top: number) => void
 }
 
 const MemoizedMessageItem = memo(MessageItem)
@@ -29,6 +30,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
   {
     chatId,
     messages,
+    firstItemIndex,
     sentMediaCache,
     onReply,
     onQuotedClick,
@@ -40,104 +42,52 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
   },
   ref,
 ) {
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const loadMoreTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const virtuosoRef = useRef<VirtuosoHandle>(null)
 
-  const scrollToBottom = useCallback((behavior: "auto" | "smooth" = "smooth") => {
-    const el = containerRef.current
-    if (el) {
-      const top = el.scrollHeight - el.clientHeight
-      try {
-        el.scrollTo({ top, behavior })
-      } catch {
-        el.scrollTop = top
-      }
-    }
-  }, [])
-
-  const scrollToMessage = useCallback((messageId: string) => {
-    const el = containerRef.current
-    if (!el) return
-
-    const messageElement = el.querySelector(`[data-message-id="${messageId}"]`) as HTMLElement
-    if (messageElement) {
-      messageElement.scrollIntoView({ behavior: "smooth", block: "center" })
-    }
-  }, [])
-
-  const getScrollHeight = useCallback(() => {
-    const el = containerRef.current
-    return el ? el.scrollHeight : 0
-  }, [])
-
-  const getScrollTop = useCallback(() => {
-    const el = containerRef.current
-    return el ? el.scrollTop : 0
-  }, [])
-
-  const setScrollTop = useCallback((top: number) => {
-    const el = containerRef.current
-    if (el) {
-      el.scrollTop = top
-    }
-  }, [])
-
-  useImperativeHandle(ref, () => ({
-    scrollToBottom,
-    scrollToMessage,
-    getScrollHeight,
-    getScrollTop,
-    setScrollTop,
-  }))
-
-  useEffect(() => {
-    return () => {
-      if (loadMoreTimeoutRef.current) {
-        clearTimeout(loadMoreTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const onScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const el = e.currentTarget
-
-      // Clear existing timeout
-      if (loadMoreTimeoutRef.current) {
-        clearTimeout(loadMoreTimeoutRef.current)
-      }
-
-      // Check if we should load more
-      const shouldLoadMore = el.scrollTop === 0 && !isLoading && hasMore && onLoadMore
-
-      if (shouldLoadMore) {
-        // Set timeout to load more after scrolling stops
-        loadMoreTimeoutRef.current = setTimeout(() => {
-          onLoadMore()
-          loadMoreTimeoutRef.current = null
-        }, 300) // Wait 300ms after scrolling stops
-      }
-
-      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 5
-      onAtBottomChange?.(atBottom)
-    },
-    [isLoading, hasMore, onLoadMore, onAtBottomChange],
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToBottom: (behavior: "auto" | "smooth" = "smooth") => {
+        virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior })
+      },
+      scrollToMessage: (messageId: string) => {
+        const index = messages.findIndex(m => m.Info.ID === messageId)
+        if (index >= 0) {
+          virtuosoRef.current?.scrollToIndex({ index, align: "center", behavior: "smooth" })
+        }
+      },
+    }),
+    [messages],
   )
 
   return (
-    <div
-      ref={containerRef}
-      onScroll={onScroll}
-      className="h-full overflow-y-auto overflow-x-hidden bg-repeat virtuoso-scroller"
-      style={{ backgroundImage: "url('/assets/images/bg-chat-tile-dark.png')" }}
-    >
-      <div className="flex justify-center py-4">
-        {isLoading ? (
-          <div className="animate-spin h-5 w-5 border-2 border-green-500 rounded-full border-t-transparent" />
-        ) : null}
-      </div>
-      {messages.map(msg => (
-        <div key={msg.Info.ID} data-message-id={msg.Info.ID} className="py-1 overflow-x-hidden">
+    <Virtuoso
+      ref={virtuosoRef}
+      className="h-full virtuoso-scroller"
+      data={messages}
+      firstItemIndex={firstItemIndex}
+      initialTopMostItemIndex={Math.max(0, messages.length - 1)}
+      // A modest buffer keeps rows ready just ahead of the viewport without
+      // mounting so many expensive rows that scrolling itself gets costly.
+      increaseViewportBy={{ top: 200, bottom: 200 }}
+      // Fires when the user scrolls to the very top -> load older messages.
+      startReached={() => {
+        if (hasMore && !isLoading) onLoadMore?.()
+      }}
+      atBottomStateChange={atBottom => onAtBottomChange?.(atBottom)}
+      // Stick to the bottom for new messages only when already at the bottom.
+      followOutput={atBottom => (atBottom ? "smooth" : false)}
+      computeItemKey={(_index, msg) => msg?.Info?.ID ?? String(_index)}
+      components={{
+        Header: () =>
+          isLoading ? (
+            <div className="flex justify-center py-4">
+              <div className="animate-spin h-5 w-5 border-2 border-green-500 rounded-full border-t-transparent" />
+            </div>
+          ) : null,
+      }}
+      itemContent={(_index, msg) => (
+        <div data-message-id={msg.Info.ID} className="py-1 overflow-x-hidden">
           <MemoizedMessageItem
             message={msg}
             chatId={chatId}
@@ -147,7 +97,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
             highlightedMessageId={highlightedMessageId}
           />
         </div>
-      ))}
-    </div>
+      )}
+    />
   )
 })

--- a/frontend/src/components/chat/Status.tsx
+++ b/frontend/src/components/chat/Status.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from "react"
+import clsx from "clsx"
+import { FetchMessagesPaged, GetCachedImage, DownloadMedia } from "../../../wailsjs/go/api/Api"
+import { store } from "../../../wailsjs/go/models"
+import { useContactStore } from "../../store/useContactStore"
+
+const STATUS_JID = "status@broadcast"
+const STORY_MS = 5000
+
+export interface StatusGroup {
+  sender: string
+  name: string
+  items: store.DecodedMessage[]
+}
+
+function last<T>(a: T[]): T {
+  return a[a.length - 1]
+}
+
+// List of people who have recent status updates. Clicking one opens the viewer.
+export function StatusList({ onOpen }: { onOpen: (g: StatusGroup) => void }) {
+  const [groups, setGroups] = useState<StatusGroup[]>([])
+  const [loading, setLoading] = useState(true)
+  const getContactName = useContactStore(s => s.getContactName)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const msgs = ((await FetchMessagesPaged(STATUS_JID, 300, 0)) || []) as store.DecodedMessage[]
+      const bySender = new Map<string, store.DecodedMessage[]>()
+      for (const m of msgs) {
+        const s = m.Info?.Sender
+        if (!s) continue
+        if (!bySender.has(s)) bySender.set(s, [])
+        bySender.get(s)!.push(m)
+      }
+      const result: StatusGroup[] = []
+      for (const [sender, items] of bySender) {
+        items.sort((a, b) => a.Info.Timestamp.localeCompare(b.Info.Timestamp))
+        let name = sender.split("@")[0].split(":")[0]
+        try {
+          name = (await getContactName(sender)) || name
+        } catch {
+          /* keep number */
+        }
+        result.push({ sender, name, items })
+      }
+      result.sort((a, b) => last(b.items).Info.Timestamp.localeCompare(last(a.items).Info.Timestamp))
+      if (!cancelled) {
+        setGroups(result)
+        setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [getContactName])
+
+  if (loading) return <div className="p-6 text-center text-sm text-gray-500">Loading status…</div>
+  if (groups.length === 0)
+    return <div className="p-6 text-center text-sm text-gray-500">No recent status updates</div>
+
+  return (
+    <div>
+      {groups.map(g => (
+        <button
+          key={g.sender}
+          onClick={() => onOpen(g)}
+          className="flex w-full items-center gap-3 p-3 text-left hover:bg-gray-100 dark:hover:bg-dark-tertiary"
+        >
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border-2 border-green-500 text-lg font-medium text-green-600 dark:text-green-400">
+            {g.name.charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-medium">{g.name}</div>
+            <div className="text-xs text-gray-500">
+              {g.items.length} update{g.items.length > 1 ? "s" : ""}
+            </div>
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// Full-screen story viewer: progress bars, auto-advance, tap/keyboard nav.
+export function StoryViewer({ group, onClose }: { group: StatusGroup; onClose: () => void }) {
+  const [idx, setIdx] = useState(0)
+  const [mediaSrc, setMediaSrc] = useState<string | null>(null)
+
+  const item = group.items[idx]
+  const content = (item?.Content || {}) as any
+  const kind: "image" | "video" | "text" = content.imageMessage
+    ? "image"
+    : content.videoMessage
+      ? "video"
+      : "text"
+  const caption =
+    content.conversation ||
+    content.extendedTextMessage?.text ||
+    content.imageMessage?.caption ||
+    content.videoMessage?.caption ||
+    ""
+
+  const next = () => setIdx(i => (i < group.items.length - 1 ? i + 1 : (onClose(), i)))
+  const prev = () => setIdx(i => (i > 0 ? i - 1 : i))
+
+  // Load media for the current item.
+  useEffect(() => {
+    setMediaSrc(null)
+    if (!item || kind === "text") return
+    let cancelled = false
+    ;(async () => {
+      let src = ""
+      if (kind === "image") src = (await GetCachedImage(item.Info.ID).catch(() => "")) || ""
+      if (!src) src = (await DownloadMedia(STATUS_JID, item.Info.ID).catch(() => "")) || ""
+      if (!cancelled) setMediaSrc(src || null)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [item, kind])
+
+  // Auto-advance (videos advance on their own end).
+  useEffect(() => {
+    if (kind === "video") return
+    const t = setTimeout(next, STORY_MS)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idx, kind])
+
+  // Keyboard nav.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+      else if (e.key === "ArrowRight") next()
+      else if (e.key === "ArrowLeft") prev()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  })
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex flex-col bg-black">
+      <div className="flex gap-1 p-2">
+        {group.items.map((_, i) => (
+          <div key={i} className="h-0.5 flex-1 overflow-hidden rounded bg-white/30">
+            {i < idx ? (
+              <div className="h-full w-full bg-white" />
+            ) : i === idx && kind !== "video" ? (
+              <div
+                key={idx}
+                className="story-active-bar h-full bg-white"
+                style={{ animationDuration: `${STORY_MS}ms` }}
+              />
+            ) : i === idx ? (
+              <div className="h-full w-full bg-white/70" />
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between px-4 pb-2 text-white">
+        <div className="font-medium">{group.name}</div>
+        <button onClick={onClose} className="text-2xl leading-none hover:text-white/70" title="Close (Esc)">
+          ×
+        </button>
+      </div>
+
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden">
+        <button onClick={prev} className="absolute left-0 top-0 z-10 h-full w-1/3" aria-label="Previous" />
+        <button onClick={next} className="absolute right-0 top-0 z-10 h-full w-1/3" aria-label="Next" />
+
+        {kind === "text" && (
+          <div
+            className="max-w-lg px-8 text-center text-2xl leading-relaxed text-white [&_a]:underline"
+            dangerouslySetInnerHTML={{ __html: caption }}
+          />
+        )}
+        {kind === "image" &&
+          (mediaSrc ? (
+            <img src={mediaSrc} alt="" className="max-h-full max-w-full object-contain" />
+          ) : (
+            <Spinner />
+          ))}
+        {kind === "video" &&
+          (mediaSrc ? (
+            <video
+              src={mediaSrc}
+              autoPlay
+              onEnded={next}
+              className="max-h-full max-w-full object-contain"
+            />
+          ) : (
+            <Spinner />
+          ))}
+
+        {kind !== "text" && caption && (
+          <div
+            className="pointer-events-none absolute bottom-6 left-0 right-0 px-8 text-center text-white [&_a]:underline"
+            dangerouslySetInnerHTML={{ __html: caption }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Spinner() {
+  return <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-white" />
+}

--- a/frontend/src/lib/self.ts
+++ b/frontend/src/lib/self.ts
@@ -1,0 +1,23 @@
+import { GetMyJID } from "../../wailsjs/go/api/Api"
+
+let myUser = ""
+
+// The phone-number part of a JID, ignoring device and server suffixes.
+export function userPart(jid: string): string {
+  return (jid || "").split("@")[0].split(":")[0]
+}
+
+export async function initSelf() {
+  try {
+    myUser = userPart(await GetMyJID())
+  } catch {
+    /* not logged in yet */
+  }
+}
+
+// Whether a reaction sender is us ("me" is the optimistic local marker).
+export function isMe(senderId: string): boolean {
+  if (!senderId) return false
+  if (senderId === "me") return true
+  return !!myUser && userPart(senderId) === myUser
+}

--- a/frontend/src/screens/ChatDetail.tsx
+++ b/frontend/src/screens/ChatDetail.tsx
@@ -27,6 +27,9 @@ interface ChatDetailProps {
 }
 
 const PAGE_SIZE = 50
+// Virtuoso needs a stable, large starting index so it can decrement as older
+// messages are prepended, keeping the scroll position anchored.
+const START_INDEX = 1_000_000
 
 export function ChatDetail({ chatId, chatName, chatAvatar, onBack }: ChatDetailProps) {
   const {
@@ -58,6 +61,15 @@ export function ChatDetail({ chatId, chatName, chatAvatar, onBack }: ChatDetailP
   const [isReady, setIsReady] = useState(false)
   const [isAtBottom, setIsAtBottom] = useState(true)
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null)
+  const [firstItemIndex, setFirstItemIndex] = useState(START_INDEX)
+
+  // Reset the Virtuoso anchor synchronously when switching chats so the fresh
+  // list (see key={chatId} on <MessageList>) starts from a clean base.
+  const anchorChatIdRef = useRef(chatId)
+  if (anchorChatIdRef.current !== chatId) {
+    anchorChatIdRef.current = chatId
+    setFirstItemIndex(START_INDEX)
+  }
 
   const messageListRef = useRef<MessageListHandle>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -149,25 +161,14 @@ export function ChatDetail({ chatId, chatName, chatAvatar, onBack }: ChatDetailP
     const oldestMessage = currentMessages[0]
     const beforeTimestamp = Math.floor(new Date(oldestMessage.Info.Timestamp).getTime() / 1000)
 
-    // Store current scroll position before loading
-    const oldScrollHeight = messageListRef.current?.getScrollHeight() || 0
-    const oldScrollTop = messageListRef.current?.getScrollTop() || 0
-
     try {
       const msgs = await FetchMessagesPaged(chatId, PAGE_SIZE, beforeTimestamp)
       if (msgs && msgs.length > 0) {
+        // Decrement the Virtuoso anchor by the number prepended so it keeps the
+        // current scroll position instead of jumping. Virtuoso handles the rest.
+        setFirstItemIndex(prev => prev - msgs.length)
         prependMessages(chatId, msgs)
         setHasMore(msgs.length >= PAGE_SIZE)
-
-        // Adjust scroll position after prepending
-        requestAnimationFrame(() => {
-          const newScrollHeight = messageListRef.current?.getScrollHeight() || 0
-          const scrollAdjustment = newScrollHeight - oldScrollHeight
-          if (messageListRef.current && scrollAdjustment > 0) {
-            const newScrollTop = oldScrollTop + scrollAdjustment
-            messageListRef.current.setScrollTop(newScrollTop)
-          }
-        })
       } else {
         setHasMore(false)
       }
@@ -455,12 +456,6 @@ export function ChatDetail({ chatId, chatName, chatAvatar, onBack }: ChatDetailP
         ease: easeShowRef.current,
       })
     }
-    if (isAtBottom) {
-      const currentMessages = messages[chatId] || []
-      if (currentMessages.length > PAGE_SIZE * 2) {
-        setMessages(chatId, currentMessages.slice(-(currentMessages.length / 2)))
-      }
-    }
   }, [isAtBottom])
 
   return (
@@ -474,6 +469,12 @@ export function ChatDetail({ chatId, chatName, chatAvatar, onBack }: ChatDetailP
         />
 
         <div className="flex-1 relative overflow-hidden">
+          {/* Static chat wallpaper: painted once behind the list instead of
+              scrolling (and repainting) with it — big scroll-perf win. */}
+          <div
+            className="absolute inset-0 bg-repeat pointer-events-none z-0"
+            style={{ backgroundImage: "url('/assets/images/bg-chat-tile-dark.png')" }}
+          />
           {(initialLoad || !isReady) && (
             <div className="absolute inset-0 flex items-center justify-center bg-[#efeae2] dark:bg-dark-bg z-50">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-500" />
@@ -495,11 +496,13 @@ export function ChatDetail({ chatId, chatName, chatAvatar, onBack }: ChatDetailP
             </svg>
           </button>
 
-          <div className={clsx("h-full", (!isReady || initialLoad) && "invisible")}>
+          <div className={clsx("relative z-10 h-full", (!isReady || initialLoad) && "invisible")}>
             <MessageList
+              key={chatId}
               ref={messageListRef}
               chatId={chatId}
               messages={chatMessages}
+              firstItemIndex={firstItemIndex}
               sentMediaCache={sentMediaCache}
               onReply={setReplyingTo}
               onQuotedClick={handleQuotedClick}

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useCallback, memo } from "react"
 import clsx from "clsx"
-import { GetChatList, GetCachedAvatar, GetSelfAvatar } from "../../wailsjs/go/api/Api"
+import { GetChatList, GetChannelList, GetCachedAvatar, GetSelfAvatar } from "../../wailsjs/go/api/Api"
 import { api } from "../../wailsjs/go/models"
 import { EventsOn } from "../../wailsjs/runtime/runtime"
 import { ChatDetail } from "./ChatDetail"
 import { useChatStore, useChatById, useFilteredChatIds } from "../store"
 import { useSelfAvatarStore } from "../store/useSelfAvatarStore"
 import type { ChatItem } from "../store/types"
+import { StatusList, StoryViewer, type StatusGroup } from "../components/chat/Status"
 import {
   GroupIcon,
   UserAvatar,
@@ -297,13 +298,19 @@ export function ChatListScreen({ onOpenSettings }: ChatListScreenProps) {
     }
   }, [setSelfAvatar])
 
+  const [view, setView] = useState<"chats" | "channels" | "status">("chats")
+  const [storyGroup, setStoryGroup] = useState<StatusGroup | null>(null)
+  const viewRef = useRef(view)
+  viewRef.current = view
+
   const fetchChats = useCallback(async () => {
     if (isFetchingRef.current) return
 
     isFetchingRef.current = true
 
     try {
-      const chatElements = await GetChatList()
+      const chatElements =
+        viewRef.current === "channels" ? await GetChannelList() : await GetChatList()
 
       if (!mountedRef.current) return
 
@@ -325,6 +332,20 @@ export function ChatListScreen({ onOpenSettings }: ChatListScreenProps) {
       isFetchingRef.current = false
     }
   }, [setChats, transformChatElements])
+
+  // Reload the list (and drop the open chat) when switching Chats/Channels.
+  const viewInitRef = useRef(true)
+  useEffect(() => {
+    if (viewInitRef.current) {
+      viewInitRef.current = false
+      return
+    }
+    selectChat(null)
+    setChats([])
+    // Status has its own data path (grouped stories); don't load it as a chat list.
+    if (view !== "status") fetchChats()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view])
 
   useEffect(() => {
     mountedRef.current = true
@@ -423,10 +444,28 @@ export function ChatListScreen({ onOpenSettings }: ChatListScreenProps) {
           )}
         >
           <Header onOpenSettings={onOpenSettings} avatar={selfAvatar} />
+          <div className="flex gap-2 border-b border-gray-100 px-3 py-2 dark:border-dark-tertiary">
+            {(["chats", "channels", "status"] as const).map(v => (
+              <button
+                key={v}
+                onClick={() => setView(v)}
+                className={clsx(
+                  "rounded-full px-3 py-1 text-sm capitalize transition-colors",
+                  view === v
+                    ? "bg-green-600 text-white"
+                    : "text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-dark-tertiary",
+                )}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
           <SearchBar value={searchTerm} onChange={setSearchTerm} />
 
           <div className="flex-1 overflow-y-auto">
-            {filteredChatIds.length === 0 ? (
+            {view === "status" ? (
+              <StatusList onOpen={setStoryGroup} />
+            ) : filteredChatIds.length === 0 ? (
               <EmptyState
                 hasChats={totalChats > 0}
                 isLoading={isFetchingRef.current}
@@ -444,6 +483,7 @@ export function ChatListScreen({ onOpenSettings }: ChatListScreenProps) {
             )}
           </div>
         </ResizablePanel>
+        {storyGroup && <StoryViewer group={storyGroup} onClose={() => setStoryGroup(null)} />}
 
         <ResizableHandle />
 

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -112,12 +112,19 @@ const ChatListItemContent = memo(({ chat, isSelected, onSelect }: ChatListItemCo
             : "yesterday"}
         </span>
       </div>
-      <div className="text-sm text-gray-500 dark:text-gray-400 truncate [&_p]:inline [&_p]:m-0 ">
-        {chat.sender && chat.type === "group" && <span className="mr-1">{chat.sender}: </span>}
-        <span
-          className="[&_br]:hidden no-formatting"
-          dangerouslySetInnerHTML={{ __html: chat.subtitle }}
-        />
+      <div className="flex items-center gap-2">
+        <div className="flex-1 text-sm text-gray-500 dark:text-gray-400 truncate [&_p]:inline [&_p]:m-0 ">
+          {chat.sender && chat.type === "group" && <span className="mr-1">{chat.sender}: </span>}
+          <span
+            className="[&_br]:hidden no-formatting"
+            dangerouslySetInnerHTML={{ __html: chat.subtitle }}
+          />
+        </div>
+        {chat.unreadCount ? (
+          <span className="shrink-0 min-w-5 h-5 px-1.5 flex items-center justify-center rounded-full bg-blue-500 text-white text-xs font-semibold">
+            {chat.unreadCount > 99 ? "99+" : chat.unreadCount}
+          </span>
+        ) : null}
       </div>
     </div>
   </div>
@@ -334,7 +341,14 @@ export function ChatListScreen({ onOpenSettings }: ChatListScreenProps) {
         timestamp: number
         sender: string
         reaction?: string
+        isFromMe?: boolean
       }) => {
+        // Mark an incoming message unread unless it belongs to the chat that's
+        // currently open. Read state via getState() to avoid a stale closure.
+        if (!data.isFromMe && useChatStore.getState().selectedChatId !== data.chatId) {
+          useChatStore.getState().incrementUnreadCount(data.chatId)
+        }
+
         if (!initialFetchDoneRef.current) {
           // If we haven't done initial fetch, do a full fetch
           setTimeout(fetchChats, 500)

--- a/frontend/src/store/useChatStore.ts
+++ b/frontend/src/store/useChatStore.ts
@@ -38,17 +38,24 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   selectedChatSender: undefined,
   searchTerm: "",
 
-  setChats: chats => {
-    const newChatsById = new Map<string, ChatItem>()
-    const newChatIds: string[] = []
+  setChats: chats =>
+    set(state => {
+      const newChatsById = new Map<string, ChatItem>()
+      const newChatIds: string[] = []
 
-    for (const chat of chats) {
-      newChatsById.set(chat.id, chat)
-      newChatIds.push(chat.id)
-    }
+      for (const chat of chats) {
+        // Preserve unread counts across a full refetch; the rebuilt items from
+        // the backend don't carry unread state.
+        const prev = state.chatsById.get(chat.id)
+        newChatsById.set(
+          chat.id,
+          prev?.unreadCount ? { ...chat, unreadCount: prev.unreadCount } : chat,
+        )
+        newChatIds.push(chat.id)
+      }
 
-    set({ chatsById: newChatsById, chatIds: newChatIds })
-  },
+      return { chatsById: newChatsById, chatIds: newChatIds }
+    }),
 
   selectChat: chat =>
     set({

--- a/frontend/src/store/useContactStore.ts
+++ b/frontend/src/store/useContactStore.ts
@@ -6,6 +6,7 @@ interface ContactStore {
   contacts: Record<string, { name: string; senderColor: string; timestamp: number }>
   getContactName: (jid: any) => Promise<string>
   getContactColor: (jid: any) => Promise<string>
+  getSenderInfo: (jid: string) => Promise<{ name: string; color: string }>
   disposeCache: () => void
 }
 
@@ -58,6 +59,29 @@ export const useContactStore = create<ContactStore>()(
         return senderColor
       } catch {
         return "#2b7fff"
+      }
+    },
+
+    // Cached name+color for a message sender, keyed by the raw JID so repeated
+    // renders while scrolling a group chat don't fire a GetContact/GetJIDUser
+    // RPC per message. One fetch per sender, then synchronous cache hits.
+    getSenderInfo: async (jid: string) => {
+      const cached = get().contacts[jid]
+      if (cached) return { name: cached.name, color: cached.senderColor }
+      try {
+        const contact = await GetContact(jid)
+        const name = contact.full_name
+          ? contact.full_name
+          : contact.push_name
+            ? "~ " + contact.push_name
+            : ""
+        const color = await GetProfileColor(jid)
+        set(state => {
+          state.contacts[jid] = { name, senderColor: color, timestamp: Date.now() }
+        })
+        return { name, color }
+      } catch {
+        return { name: "", color: "#2b7fff" }
       }
     },
 

--- a/frontend/src/store/useMessageStore.ts
+++ b/frontend/src/store/useMessageStore.ts
@@ -10,6 +10,12 @@ interface MessageStore {
   addMessage: (chatId: string, message: any) => void
   prependMessages: (chatId: string, messages: any[]) => void
   updateMessage: (chatId: string, message: any) => void
+  addReactionToMessage: (
+    chatId: string,
+    messageId: string,
+    emoji: string,
+    senderId: string,
+  ) => void
   clearMessages: (chatId: string) => void
   trimOldMessages: (chatId: string, keepCount: number) => void
   addPendingMessage: (chatId: string, message: any) => void
@@ -66,6 +72,25 @@ export const useMessageStore = create<MessageStore>()(
         } else {
           state.messages[chatId].push(message)
         }
+      }),
+
+    // Optimistically set/clear a sender's reaction on a message (empty emoji
+    // removes it). One reaction per sender.
+    addReactionToMessage: (chatId, messageId, emoji, senderId) =>
+      set(state => {
+        const msgs = state.messages[chatId]
+        if (!msgs) return
+        const idx = msgs.findIndex((m: any) => m.Info?.ID === messageId)
+        if (idx < 0) return
+        const msg = msgs[idx]
+        // Dedupe by the phone-number part so an optimistic reaction replaces a
+        // previously-synced one from the same person (which carries a full JID).
+        const uid = (s: string) => (s || "").split("@")[0].split(":")[0]
+        const target = uid(senderId)
+        const others = (msg.reactions || []).filter((r: any) => uid(r.sender_id) !== target)
+        msg.reactions = emoji
+          ? [...others, { id: 0, message_id: messageId, sender_id: senderId, emoji }]
+          : others
       }),
 
     trimOldMessages: (chatId, keepCount) =>

--- a/frontend/src/store/useUIStore.ts
+++ b/frontend/src/store/useUIStore.ts
@@ -15,6 +15,10 @@ interface UIStore {
   setOnlineStatus: (userId: string, isOnline: boolean) => void
   addNotification: (message: string) => number
   removeNotification: (id: number) => void
+  lightboxSrc: string | null
+  lightboxKind: "image" | "video"
+  openLightbox: (src: string, kind?: "image" | "video") => void
+  closeLightbox: () => void
 }
 
 export const useUIStore = create<UIStore>(set => ({
@@ -24,6 +28,11 @@ export const useUIStore = create<UIStore>(set => ({
   typingIndicators: {},
   onlineStatus: {},
   notifications: [],
+
+  lightboxSrc: null,
+  lightboxKind: "image",
+  openLightbox: (src, kind = "image") => set({ lightboxSrc: src, lightboxKind: kind }),
+  closeLightbox: () => set({ lightboxSrc: null }),
 
   toggleSidebar: () => set(state => ({ sidebarOpen: !state.sidebarOpen })),
   setSidebarOpen: open => set({ sidebarOpen: open }),

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -257,3 +257,14 @@ a {
 video::-webkit-media-controls-fullscreen-button {
   display: none !important;
 }
+
+/* Status story progress bar fill. */
+@keyframes storyFill {
+  from { width: 0%; }
+  to { width: 100%; }
+}
+.story-active-bar {
+  animation-name: storyFill;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -242,3 +242,11 @@ a {
   -webkit-font-smoothing: subpixel-antialiased;
   image-rendering: auto;
 }
+
+/* Clickable links inside message text (opened in system browser via App.tsx). */
+.msg-link {
+  color: #53bdeb;
+  text-decoration: underline;
+  cursor: pointer;
+  word-break: break-all;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -250,3 +250,10 @@ a {
   cursor: pointer;
   word-break: break-all;
 }
+
+/* WebKitGTK's native <video> fullscreen button opens a broken black view, and
+   controlsList="nofullscreen" isn't honored — hide it via the WebKit pseudo-
+   element. The app's lightbox already provides a full-viewport view. */
+video::-webkit-media-controls-fullscreen-button {
+  display: none !important;
+}

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -1,12 +1,39 @@
 package markdown
 
-// TODO :  URL parsing, triple backtick blocks
+// TODO :  triple backtick blocks
 import (
 	"html"
+	"regexp"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 )
+
+var urlRE = regexp.MustCompile(`https?://[^\s<]+|www\.[^\s<]+`)
+
+// linkifyAndEscape HTML-escapes plain text and wraps any URLs in anchor tags
+// (class msg-link so the frontend can open them in the system browser).
+func linkifyAndEscape(s string) string {
+	var out strings.Builder
+	last := 0
+	for _, loc := range urlRE.FindAllStringIndex(s, -1) {
+		out.WriteString(html.EscapeString(s[last:loc[0]]))
+		raw := s[loc[0]:loc[1]]
+		// Trim trailing punctuation that's usually sentence punctuation, not URL.
+		trimmed := strings.TrimRight(raw, ".,!?;:)")
+		trailing := raw[len(trimmed):]
+		href := trimmed
+		if strings.HasPrefix(trimmed, "www.") {
+			href = "https://" + trimmed
+		}
+		out.WriteString(`<a href="` + html.EscapeString(href) +
+			`" class="msg-link" rel="noreferrer noopener">` + html.EscapeString(trimmed) + `</a>`)
+		out.WriteString(html.EscapeString(trailing))
+		last = loc[1]
+	}
+	out.WriteString(html.EscapeString(s[last:]))
+	return out.String()
+}
 
 var Tokens = map[string]string{
 	"*": "b",
@@ -37,7 +64,7 @@ func ParseInline(s string) string {
 
 	flushPlain := func() {
 		if buf.Len() > 0 {
-			out.WriteString(html.EscapeString(buf.String()))
+			out.WriteString(linkifyAndEscape(buf.String()))
 			buf.Reset()
 		}
 	}
@@ -99,13 +126,13 @@ func ParseInline(s string) string {
 		content := buf.String()[openPos+len(active) : lastClose]
 		after := buf.String()[lastClose+len(active):]
 
-		out.WriteString(html.EscapeString(before))
+		out.WriteString(linkifyAndEscape(before))
 		out.WriteString(openTag(Tokens[active]))
 		out.WriteString(html.EscapeString(content))
 		out.WriteString(closeTag(Tokens[active]))
-		out.WriteString(html.EscapeString(after))
+		out.WriteString(linkifyAndEscape(after))
 	} else {
-		out.WriteString(html.EscapeString(buf.String()))
+		out.WriteString(linkifyAndEscape(buf.String()))
 	}
 
 	return out.String()

--- a/internal/query/link_previews.go
+++ b/internal/query/link_previews.go
@@ -1,0 +1,44 @@
+package query
+
+const (
+	CreateLinkPreviewsTable = `
+	CREATE TABLE IF NOT EXISTS link_previews (
+		message_id TEXT PRIMARY KEY,
+		url TEXT,
+		title TEXT,
+		description TEXT,
+		thumbnail BLOB,
+		direct_path TEXT,
+		media_key BLOB,
+		file_sha256 BLOB,
+		file_enc_sha256 BLOB
+	);
+	`
+
+	// Migrations for link_previews tables created before the poster-download
+	// key columns existed. Caller ignores the "duplicate column" error.
+	AddLinkPreviewDirectPath = `ALTER TABLE link_previews ADD COLUMN direct_path TEXT;`
+	AddLinkPreviewMediaKey   = `ALTER TABLE link_previews ADD COLUMN media_key BLOB;`
+	AddLinkPreviewFileSHA    = `ALTER TABLE link_previews ADD COLUMN file_sha256 BLOB;`
+	AddLinkPreviewFileEncSHA = `ALTER TABLE link_previews ADD COLUMN file_enc_sha256 BLOB;`
+
+	InsertLinkPreview = `
+	INSERT OR REPLACE INTO link_previews
+	(message_id, url, title, description, thumbnail, direct_path, media_key, file_sha256, file_enc_sha256)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+	`
+
+	SelectLinkPreviewByMessageID = `
+	SELECT url, title, description, thumbnail FROM link_previews WHERE message_id = ?;
+	`
+
+	// Download info + any cached thumbnail for lazily fetching the poster image.
+	SelectLinkPreviewMediaByMessageID = `
+	SELECT thumbnail, direct_path, media_key, file_sha256, file_enc_sha256
+	FROM link_previews WHERE message_id = ?;
+	`
+
+	UpdateLinkPreviewThumbnail = `
+	UPDATE link_previews SET thumbnail = ? WHERE message_id = ?;
+	`
+)

--- a/internal/query/message_media.go
+++ b/internal/query/message_media.go
@@ -14,25 +14,34 @@ const (
 		width INTEGER,
 		height INTEGER,
 		file_name TEXT,
-		gif_playback INTEGER DEFAULT 0
+		gif_playback INTEGER DEFAULT 0,
+		thumbnail BLOB
 	);
 	`
 
-	// AddGifPlaybackColumn migrates existing message_media tables that predate
-	// the gif_playback column. SQLite has no ADD COLUMN IF NOT EXISTS, so the
-	// caller ignores the "duplicate column" error on subsequent runs.
+	// AddGifPlaybackColumn / AddThumbnailColumn migrate existing message_media
+	// tables that predate those columns. SQLite has no ADD COLUMN IF NOT EXISTS,
+	// so the caller ignores the "duplicate column" error on subsequent runs.
 	AddGifPlaybackColumn = `
 	ALTER TABLE message_media ADD COLUMN gif_playback INTEGER DEFAULT 0;
 	`
 
+	AddThumbnailColumn = `
+	ALTER TABLE message_media ADD COLUMN thumbnail BLOB;
+	`
+
 	InsertMessageMedia = `
 	INSERT OR REPLACE INTO message_media
-	(message_id, type, url, mimetype, direct_path, media_key, file_sha256, file_enc_sha256, width, height, file_name, gif_playback)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+	(message_id, type, url, mimetype, direct_path, media_key, file_sha256, file_enc_sha256, width, height, file_name, gif_playback, thumbnail)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 	`
 
 	SelectGifPlaybackByMessageID = `
 	SELECT gif_playback FROM message_media WHERE message_id = ?;
+	`
+
+	SelectThumbnailByMessageID = `
+	SELECT thumbnail FROM message_media WHERE message_id = ?;
 	`
 
 	UpdateMessageMediaByMessageID = `

--- a/internal/query/messages.go
+++ b/internal/query/messages.go
@@ -113,6 +113,24 @@ const (
 	ORDER BY m.timestamp DESC;
 	`
 
+	// Same as SelectDecodedChatList but only Channels (newsletter feeds).
+	SelectDecodedChannelList = `
+	SELECT m.message_id, m.chat_jid, m.sender_jid, m.timestamp, m.is_from_me, m.text, m.reply_to_message_id, m.edited, m.forwarded, mm.type, mm.file_name
+	FROM (
+		SELECT
+			message_id, chat_jid, sender_jid, timestamp, is_from_me, text, reply_to_message_id, edited, forwarded,
+			ROW_NUMBER() OVER (
+				PARTITION BY chat_jid
+				ORDER BY timestamp DESC
+			) AS rn
+		FROM messages
+	) AS m
+	LEFT JOIN message_media AS mm ON mm.message_id = m.message_id
+	WHERE rn = 1
+	  AND m.chat_jid LIKE '%@newsletter'
+	ORDER BY m.timestamp DESC;
+	`
+
 	UpdateMessagesChat = `
 	UPDATE messages
 	SET chat_jid = ?

--- a/internal/query/messages.go
+++ b/internal/query/messages.go
@@ -108,6 +108,8 @@ const (
 	) AS m
 	LEFT JOIN message_media AS mm ON mm.message_id = m.message_id
 	WHERE rn = 1
+	  AND m.chat_jid NOT LIKE '%@newsletter'
+	  AND m.chat_jid NOT LIKE '%@broadcast'
 	ORDER BY m.timestamp DESC;
 	`
 

--- a/internal/store/message.go
+++ b/internal/store/message.go
@@ -159,7 +159,22 @@ func NewMessageStore() (*MessageStore, error) {
 			return err
 		}
 		_, err = tx.Exec(query.CreateReadReceiptsTable)
-		return err
+		if err != nil {
+			return err
+		}
+		if _, err = tx.Exec(query.CreateLinkPreviewsTable); err != nil {
+			return err
+		}
+		// Add poster-download key columns to pre-existing link_previews tables.
+		for _, mig := range []string{
+			query.AddLinkPreviewDirectPath, query.AddLinkPreviewMediaKey,
+			query.AddLinkPreviewFileSHA, query.AddLinkPreviewFileEncSHA,
+		} {
+			if _, aerr := tx.Exec(mig); aerr != nil && !strings.Contains(aerr.Error(), "duplicate column") {
+				return aerr
+			}
+		}
+		return nil
 	})
 
 	if err != nil {
@@ -524,6 +539,23 @@ func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Messag
 		thumbnail = i.GetJPEGThumbnail()
 	}
 
+	// Link preview (title/description/thumbnail) from a text message with a URL.
+	// The poster image is usually a downloadable reference rather than embedded,
+	// so keep its keys to fetch it lazily later.
+	var lpURL, lpTitle, lpDesc, lpDirectPath string
+	var lpThumb, lpMediaKey, lpFileSHA, lpFileEncSHA []byte
+	if etm := msg.GetExtendedTextMessage(); etm != nil && (etm.GetTitle() != "" || len(etm.GetJPEGThumbnail()) > 0 || etm.GetThumbnailDirectPath() != "") {
+		lpURL = etm.GetMatchedText()
+		lpTitle = etm.GetTitle()
+		lpDesc = etm.GetDescription()
+		lpThumb = etm.GetJPEGThumbnail()
+		lpDirectPath = etm.GetThumbnailDirectPath()
+		lpMediaKey = etm.GetMediaKey()
+		lpFileSHA = etm.GetThumbnailSHA256()
+		lpFileEncSHA = etm.GetThumbnailEncSHA256()
+	}
+	hasPreview := lpTitle != "" || len(lpThumb) > 0 || lpDirectPath != ""
+
 	if parsedHTML != "" {
 		text = parsedHTML
 	}
@@ -544,6 +576,12 @@ func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Messag
 		)
 		if err != nil {
 			return err
+		}
+		if hasPreview {
+			if _, perr := tx.Exec(query.InsertLinkPreview, info.ID, lpURL, lpTitle, lpDesc, lpThumb,
+				lpDirectPath, lpMediaKey, lpFileSHA, lpFileEncSHA); perr != nil {
+				return perr
+			}
 		}
 		// no media to process
 		if emc == nil {
@@ -1225,6 +1263,52 @@ func (ms *MessageStore) GetThumbnail(messageID string) []byte {
 		return nil
 	}
 	return thumb
+}
+
+// LinkPreview is the stored preview for a URL in a text message.
+type LinkPreview struct {
+	URL         string
+	Title       string
+	Description string
+	Thumbnail   []byte
+}
+
+// GetLinkPreview returns the stored link preview for a message, or nil if none.
+func (ms *MessageStore) GetLinkPreview(messageID string) *LinkPreview {
+	var lp LinkPreview
+	err := ms.db.QueryRow(query.SelectLinkPreviewByMessageID, messageID).
+		Scan(&lp.URL, &lp.Title, &lp.Description, &lp.Thumbnail)
+	if err != nil {
+		return nil
+	}
+	return &lp
+}
+
+// LinkPreviewMedia holds a cached poster (if any) and the keys to download it.
+type LinkPreviewMedia struct {
+	Thumbnail     []byte
+	DirectPath    string
+	MediaKey      []byte
+	FileSHA256    []byte
+	FileEncSHA256 []byte
+}
+
+// GetLinkPreviewMedia returns the cached poster and its download keys.
+func (ms *MessageStore) GetLinkPreviewMedia(messageID string) *LinkPreviewMedia {
+	var m LinkPreviewMedia
+	var dp sql.NullString
+	err := ms.db.QueryRow(query.SelectLinkPreviewMediaByMessageID, messageID).
+		Scan(&m.Thumbnail, &dp, &m.MediaKey, &m.FileSHA256, &m.FileEncSHA256)
+	if err != nil {
+		return nil
+	}
+	m.DirectPath = dp.String
+	return &m
+}
+
+// CacheLinkPreviewThumbnail stores a downloaded poster so it's only fetched once.
+func (ms *MessageStore) CacheLinkPreviewThumbnail(messageID string, data []byte) {
+	_, _ = ms.db.Exec(query.UpdateLinkPreviewThumbnail, data, messageID)
 }
 
 // GetDecodedMessage returns a single decoded message from messages.db

--- a/internal/store/message.go
+++ b/internal/store/message.go
@@ -142,9 +142,12 @@ func NewMessageStore() (*MessageStore, error) {
 		if err != nil {
 			return err
 		}
-		// Migrate pre-existing tables: add gif_playback if missing. Ignore the
-		// "duplicate column name" error that occurs once the column exists.
+		// Migrate pre-existing tables: add gif_playback / thumbnail if missing.
+		// Ignore the "duplicate column name" error once the column exists.
 		if _, aerr := tx.Exec(query.AddGifPlaybackColumn); aerr != nil && !strings.Contains(aerr.Error(), "duplicate column") {
+			return aerr
+		}
+		if _, aerr := tx.Exec(query.AddThumbnailColumn); aerr != nil && !strings.Contains(aerr.Error(), "duplicate column") {
 			return aerr
 		}
 		_, err = tx.Exec(query.CreatePinnedMessagesTable)
@@ -512,6 +515,15 @@ func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Messag
 	// nil-safe and returns false for non-video messages.
 	gifPlayback := msg.GetVideoMessage().GetGifPlayback()
 
+	// Embedded preview thumbnail (WhatsApp ships a small JPEG in the message) so
+	// videos show a preview + play button in the list without downloading them.
+	var thumbnail []byte
+	if v := msg.GetVideoMessage(); v != nil {
+		thumbnail = v.GetJPEGThumbnail()
+	} else if i := msg.GetImageMessage(); i != nil {
+		thumbnail = i.GetJPEGThumbnail()
+	}
+
 	if parsedHTML != "" {
 		text = parsedHTML
 	}
@@ -549,6 +561,7 @@ func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Messag
 			width, height,
 			fileName,
 			gifPlayback,
+			thumbnail,
 		)
 		return err
 	})
@@ -1202,6 +1215,16 @@ func (ms *MessageStore) isGifPlayback(messageID string) bool {
 		return false
 	}
 	return gif.Bool
+}
+
+// GetThumbnail returns the stored preview JPEG bytes for a message, or nil if
+// none was stored (e.g. messages synced before the thumbnail column existed).
+func (ms *MessageStore) GetThumbnail(messageID string) []byte {
+	var thumb []byte
+	if err := ms.db.QueryRow(query.SelectThumbnailByMessageID, messageID).Scan(&thumb); err != nil {
+		return nil
+	}
+	return thumb
 }
 
 // GetDecodedMessage returns a single decoded message from messages.db

--- a/internal/store/message.go
+++ b/internal/store/message.go
@@ -833,8 +833,18 @@ func (ms *MessageStore) GetMessageWithMediaByID(messageID string) (*ExtendedMess
 }
 
 // GetChatList returns the chat list from messages.db
+// GetChatList returns the regular chat list (channels/broadcast excluded).
 func (ms *MessageStore) GetChatList() []ChatMessage {
-	rows, err := ms.db.Query(query.SelectDecodedChatList)
+	return ms.chatListFromQuery(query.SelectDecodedChatList)
+}
+
+// GetChannelList returns only Channel (newsletter) feeds.
+func (ms *MessageStore) GetChannelList() []ChatMessage {
+	return ms.chatListFromQuery(query.SelectDecodedChannelList)
+}
+
+func (ms *MessageStore) chatListFromQuery(q string) []ChatMessage {
+	rows, err := ms.db.Query(q)
 	if err != nil {
 		log.Println("Failed to query chat list:", err)
 		return []ChatMessage{}

--- a/internal/store/message.go
+++ b/internal/store/message.go
@@ -260,6 +260,32 @@ func openDB() (*sql.DB, error) {
 	return db, nil
 }
 
+// UnwrapMessage peels off container messages (ephemeral / view-once /
+// device-sent / document-with-caption) to reach the real content. whatsmeow
+// does this for live messages, but not for history-sync (ParseWebMessage),
+// which otherwise leaves disappearing-message content looking "unsupported".
+func UnwrapMessage(m *waE2E.Message) *waE2E.Message {
+	for m != nil {
+		switch {
+		case m.GetEphemeralMessage().GetMessage() != nil:
+			m = m.GetEphemeralMessage().GetMessage()
+		case m.GetViewOnceMessage().GetMessage() != nil:
+			m = m.GetViewOnceMessage().GetMessage()
+		case m.GetViewOnceMessageV2().GetMessage() != nil:
+			m = m.GetViewOnceMessageV2().GetMessage()
+		case m.GetViewOnceMessageV2Extension().GetMessage() != nil:
+			m = m.GetViewOnceMessageV2Extension().GetMessage()
+		case m.GetDeviceSentMessage().GetMessage() != nil:
+			m = m.GetDeviceSentMessage().GetMessage()
+		case m.GetDocumentWithCaptionMessage().GetMessage() != nil:
+			m = m.GetDocumentWithCaptionMessage().GetMessage()
+		default:
+			return m
+		}
+	}
+	return m
+}
+
 // ExtractMessageText extracts a text representation from a WhatsApp message
 func ExtractMessageText(msg *waE2E.Message) string {
 	if msg.GetConversation() != "" {
@@ -483,6 +509,7 @@ func (ms *MessageStore) ProcessMessageEvent(ctx context.Context, sd store.LIDSto
 
 // InsertMessage inserts a new message into messages.db
 func (ms *MessageStore) InsertMessage(info *types.MessageInfo, msg *waE2E.Message, parsedHTML string) error {
+	msg = UnwrapMessage(msg)
 	var (
 		text, fileName, replyToMessageID string
 		forwarded                        = false


### PR DESCRIPTION
Follow-up to #97–#100 (thanks for merging!). This bundles the feature work I've built on top while daily-driving the client. The commits are individually scoped and can be reviewed one-by-one; I've kept them together because they share files (MessageItem, MediaContent, message.go, App.tsx…) so splitting them would just create mutual conflicts. Happy to reorganize however you prefer.

**Commits:**
- **perf: virtualize the message list** — react-virtuoso + a static chat wallpaper + dropping per-bubble box-shadow took long-chat scrolling from ~40fps to a locked 60 (profiled: it was paint-bound, not React).
- **media: auto-load on visibility, video thumbnails + play button, correct MIME** — IntersectionObserver lazy-load, embedded video thumbnails, and a data-URL MIME fix so video/voice actually play.
- **links: linkify URLs** (open in system browser via BrowserOpenURL) **+ link preview cards** with lazily-downloaded poster images.
- **reactions: send / swap / remove** — hover trigger, quick-reactions + full emoji picker, optimistic display, toggle-off to remove.
- **notifications + unread** — background desktop notifications (focus-gated) and unread badges + chat bump-to-top.
- **lightbox** — full-screen image (zoom) and video viewer.
- **channels + status** — a Chats/Channels/Status toggle: Channels lists @newsletter feeds; Status groups status@broadcast into a story viewer; and channel/broadcast JIDs are filtered out of the main chat list.
- **fix: unwrap ephemeral/view-once containers from history sync** — ParseWebMessage (unlike the live path's UnwrapRaw) left disappearing-message group content unreachable, showing as 'Unsupported Message Type'.

Builds with `wails build -tags webkit2_41`, running as my daily driver on Linux/Wayland. 🤖 Generated with [Claude Code](https://claude.com/claude-code)